### PR TITLE
fix(release): unblock changesets version (Prettier 3 + ignore private docs)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["docs"]
 }

--- a/.changeset/sve-ui-2026-rewrite.md
+++ b/.changeset/sve-ui-2026-rewrite.md
@@ -1,5 +1,5 @@
 ---
-"sve-ui": minor
+'sve-ui': minor
 ---
 
 Complete 2026 rewrite. Sve-UI is now a library of ready-made, fully styled and

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,5 @@
 	"trailingComma": "none",
 	"printWidth": 100,
 	"plugins": ["prettier-plugin-svelte"],
-	"pluginSearchDirs": ["."],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/packages/sve-ui/src/tests/setup.ts
+++ b/packages/sve-ui/src/tests/setup.ts
@@ -1,0 +1,17 @@
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/svelte';
+
+/**
+ * Bits UI's body-scroll-lock schedules `resetBodyStyle` on a ~24ms setTimeout
+ * whenever an overlay (Dialog/Popover/etc.) closes or unmounts. If a test file
+ * ends with an overlay still open, that timer fires AFTER vitest tears down the
+ * jsdom environment, throwing "ReferenceError: document is not defined" and
+ * failing the run even though every test passed.
+ *
+ * Unmount eagerly, then wait past the timer so it runs while `document` still
+ * exists. (cleanup() is idempotent with @testing-library's auto-cleanup.)
+ */
+afterEach(async () => {
+  cleanup();
+  await new Promise((resolve) => setTimeout(resolve, 50));
+});

--- a/packages/sve-ui/vite.config.ts
+++ b/packages/sve-ui/vite.config.ts
@@ -12,6 +12,6 @@ export default defineConfig({
 		include: ['src/tests/**/*.{test,spec}.{js,ts,svelte.ts}'],
 		environment: 'jsdom',
 		globals: true,
-		setupFiles: [],
+		setupFiles: ['./src/tests/setup.ts'],
 	},
 });


### PR DESCRIPTION
## What

Unblocks the **Release** workflow, which failed on merge to `main` while running `changeset version`.

## Root causes

1. **`ERR_MODULE_NOT_FOUND` during changelog formatting** — `.prettierrc` still had `pluginSearchDirs`, an option **removed in Prettier 3**. Changesets formats changelogs with its own Prettier 3 instance; the stale option made it try to resolve plugins via the old search path and crash. Removed it (the `prettier-plugin-svelte` plugin stays loaded via `plugins`, so `pnpm format` is unaffected).
2. **`ENOENT apps/docs/CHANGELOG.md`** — the private `docs` app was being versioned as an internal dependent, so the action expected a changelog that never got written. Added `docs` to the Changesets `ignore` list; only `sve-ui` is versioned/published now.

## Verification

- `pnpm exec prettier` loads the config + svelte plugin with no module error.
- `pnpm changeset status` → only `sve-ui` (minor → 0.2.0); `docs` no longer bumped.

After merge, the Release workflow should open the **Version Packages** PR cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
