### PR TITLE
fix(build): cache adapter-vercel output in Turborepo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,9 +1,10 @@
 {
   "$schema": "https://turborepo.dev/schema.json",
+  "globalPassThroughEnv": ["ENABLE_EXPERIMENTAL_COREPACK"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".svelte-kit/**", "build/**"]
+      "outputs": ["dist/**", ".svelte-kit/**", "build/**", ".vercel/**"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## What

Fixes the Vercel deploy error `No Output Directory named "public" found`, which persisted even after setting Framework Preset = SvelteKit.

## Root cause

The build was served from the Turborepo cache (`FULL TURBO`), but `turbo.json` only declared `dist/**`, `.svelte-kit/**`, `build/**` as build `outputs` — **not `.vercel/**`**. `@sveltejs/adapter-vercel` writes its Build Output API directory to `.vercel/output`. Since Turborepo didn't track it, a cache hit "succeeded" without ever materializing `.vercel/output`, so Vercel found no adapter output and fell back to looking for a static `public/` dir.

## Fix

- Add `.vercel/**` to the build task `outputs` so Turborepo caches and restores the adapter output on cache hits.
- Declare `ENABLE_EXPERIMENTAL_COREPACK` as `globalPassThroughEnv` (silences the Turborepo platform-env warning; corepack itself runs at install time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
