### PR TITLE
docs: add package README (npm storefront) and refresh repo README

### DIFF
--- a/.changeset/readme-storefront.md
+++ b/.changeset/readme-storefront.md
@@ -1,0 +1,7 @@
+---
+'sve-ui': patch
+---
+
+Add a package README (shown on npm) and a sharper package description covering
+the wedge: styled + accessible Svelte 5 components on Bits UI, no Tailwind/config,
+themeable via CSS variables.

--- a/README.md
+++ b/README.md
@@ -1,94 +1,65 @@
-# Sve-UI
-## _Best UI components library for Svelte_
+<div align="center">
 
-Sve-UI is a UI component library for Svelte that provides the best collection of components for building modern web applications and fast.
+# Sve·UI
 
-<br />
+**Styled, accessible Svelte 5 components — zero config.**
 
----
+[![npm](https://img.shields.io/npm/v/sve-ui?color=F56565)](https://www.npmjs.com/package/sve-ui)
+[![license](https://img.shields.io/npm/l/sve-ui?color=F56565)](./LICENSE)
+[![Svelte 5](https://img.shields.io/badge/Svelte-5-FF3E00)](https://svelte.dev)
 
-<br />
+</div>
 
-## Features
-
-- Responsive components that work seamlessly across all devices and screen sizes
-- Easy to use and highly customizable components
-- Well-documented API and usage examples
-- Regularly updated with new components and features
-
-<br />
-
----
-
-<br />
-
-## Installation
-
-> You can install Sve-UI using pnpm, npm or yarn.
+A library of ready-made, fully **styled** and fully **accessible** Svelte 5
+components built on [Bits UI](https://bits-ui.com). **No Tailwind, no config** in
+your project — install, import the stylesheet, and theme everything with CSS
+custom properties.
 
 ```sh
 pnpm add sve-ui
-npm install sve-ui
-yarn add sve-ui
 ```
 
-To use:
+➡️ **Usage, components and theming:** see the [package README](./packages/sve-ui/README.md).
+
+## Repository
+
+This is a [pnpm](https://pnpm.io) + [Turborepo](https://turborepo.dev) monorepo.
+
+```
+packages/
+  sve-ui/            # the published library (Svelte 5 + Bits UI)
+  eslint-config/     # shared @repo/eslint-config (flat config)
+  typescript-config/ # shared @repo/typescript-config
+apps/
+  docs/              # documentation site (SvelteKit 2 + Tailwind 4) → sveui.org
+```
+
+Shared dependency versions live in the pnpm **catalog** in `pnpm-workspace.yaml`
+(single source of truth). pnpm is mandatory (`preinstall` enforces it).
+
+## Development
 
 ```sh
-<script>
-  import { Button } from 'sve-ui';
-
-  function handleClick() {
-    alert('Button clicked!');
-  }
-</script>
-
-<Button onClick={handleClick}>Click me!</Button>
+pnpm install          # install the workspace
+pnpm dev              # run dev tasks (docs at localhost:5173)
+pnpm build            # build all packages (turbo)
+pnpm lint             # eslint (.svelte) + oxlint (.ts/.js)
+pnpm check            # svelte-check
+pnpm test             # vitest
 ```
 
----
+Linting is hybrid: **Oxlint** for `.ts`/`.js`, **eslint-plugin-svelte** for
+`.svelte` templates.
 
-<br />
+## Releasing
 
-## Showcase & docs
+Versioning and publishing use [Changesets](https://github.com/changesets/changesets)
+with npm **Trusted Publishing (OIDC)** — no tokens, automatic provenance.
 
-<br />
-
-
-| Showcase | Link |
-| ------ | ------ |
-| Docs | [/docs][docs] |
-| Github page | [/sve-ui][Gp] |
-| GitHub issues | [/sve-ui/issues][Gpi] |
-| Github PR | [/sve-ui/pulls][Gppr] |
-| Npmjs | [/package/sve-ui][LSjs] |
-
-<br />
-
----
-
-<br />
-
-## List of components
-
-- Box, Center, Spacer, Flex, Grid, GridItem
-- Button, Text
-- CodeExample
-- Square, Circle
-
-<br />
-
----
-
-<br />
+1. Add a changeset describing your change: `pnpm changeset`
+2. Merge to `main` → a **"Version Packages"** PR is opened automatically.
+3. Merge that PR → the library is built, validated and published to npm.
 
 ## License
 
-MIT
-
-
-[Gp]: <https://github.com/rodriabregu/sve-ui>
-[Gpi]: <https://github.com/rodriabregu/sve-ui/issues>
-[Gppr]: <https://github.com/rodriabregu/sve-ui/pulls>
-[LSjs]: <https://www.npmjs.com/package/sve-ui>
-[docs]: <https://sveui.org/>
+[MIT](./LICENSE) © Rodrigo Abregu

--- a/packages/sve-ui/README.md
+++ b/packages/sve-ui/README.md
@@ -1,0 +1,126 @@
+<div align="center">
+
+# Sve·UI
+
+**Styled, accessible Svelte 5 components — zero config.**
+
+[![npm](https://img.shields.io/npm/v/sve-ui?color=F56565)](https://www.npmjs.com/package/sve-ui)
+[![license](https://img.shields.io/npm/l/sve-ui?color=F56565)](https://github.com/rodriabregu/sve-ui/blob/main/LICENSE)
+[![Svelte 5](https://img.shields.io/badge/Svelte-5-FF3E00)](https://svelte.dev)
+
+</div>
+
+A library of ready-made, fully **styled** and fully **accessible** Svelte 5
+components, built on [Bits UI](https://bits-ui.com). The wedge: it needs **no
+Tailwind and no config** in your project. Install, import the stylesheet once,
+and use — then theme everything with CSS custom properties.
+
+```sh
+pnpm add sve-ui
+```
+
+## Why Sve·UI
+
+- **No Tailwind, no config** — styles ship with the package. No `tailwind.config`,
+  no PostCSS, no utility classes in your app.
+- **Accessible by default** — overlays are built on Bits UI: WAI-ARIA, focus traps,
+  keyboard navigation.
+- **Themeable** — every color, radius and spacing value is a `--sve-*` CSS variable.
+  Light and dark out of the box.
+- **Svelte 5 + runes** — modern, typed, tree-shakeable, ships with provenance.
+
+## Quick start
+
+Import the stylesheet once (e.g. in your root layout), then use the components:
+
+```svelte
+<script>
+	import 'sve-ui/theme.css';
+	import { Button } from 'sve-ui';
+</script>
+
+<Button color="primary">Ship it</Button>
+```
+
+Wrap your app in `ThemeProvider` to control light/dark (optional — components work
+without it):
+
+```svelte
+<script>
+	import { ThemeProvider, Button, Dialog } from 'sve-ui';
+</script>
+
+<ThemeProvider colorScheme="dark">
+	<Dialog.Root>
+		<Dialog.Trigger>
+			{#snippet child({ props })}
+				<Button {...props}>Open dialog</Button>
+			{/snippet}
+		</Dialog.Trigger>
+		<Dialog.Overlay />
+		<Dialog.Content>
+			<Dialog.Title>Delete project?</Dialog.Title>
+			<Dialog.Description>This action can't be undone.</Dialog.Description>
+		</Dialog.Content>
+	</Dialog.Root>
+</ThemeProvider>
+```
+
+## Components
+
+**Display & form** — `Button`, `Input`, `Card`, `Badge`, `Avatar`, `Spinner`,
+`Text`, `Heading`, `Alert`.
+
+**Overlays** (on Bits UI) — `Dialog`, `DropdownMenu`, `Tooltip`, `Popover`.
+
+Most components take `variant`, `color` and `size` props, e.g.:
+
+```svelte
+<Button variant="solid" color="primary">Primary</Button>
+<Button variant="outline" color="danger">Danger</Button>
+<Badge variant="subtle" color="success">Active</Badge>
+<Input variant="outline" size="md" placeholder="you@example.com" bind:value />
+```
+
+Overlays (`Dialog`, `DropdownMenu`, `Tooltip`, `Popover`, plus `Avatar`, `Card`,
+`Alert`) are **namespaced** compositions — import the namespace and compose its
+parts (`Dialog.Root`, `Dialog.Trigger`, `Dialog.Content`, …).
+
+## Theming
+
+All design tokens are CSS custom properties under `:root`, established by
+`sve-ui/theme.css`. Override any of them to retheme — no rebuild, no config:
+
+```css
+:root {
+	--sve-color-primary: #8b5cf6;
+	--sve-radius-md: 0.5rem;
+}
+```
+
+Semantic color roles (`primary`, `secondary`, `success`, `warning`, `danger`,
+`default`) each expose `…-foreground`, `…-surface`, `…-border`, `…-hover` and
+`…-active` variants. Light and dark are both included; `ThemeProvider` toggles
+the scheme via a `colorScheme` prop (`"light" | "dark" | "system"`) and can apply
+per-subtree token overrides via its `theme` prop.
+
+## Package exports
+
+| Import             | What                                                               |
+| ------------------ | ------------------------------------------------------------------ |
+| `sve-ui`           | All components, `ThemeProvider`, variant helpers and types         |
+| `sve-ui/theme`     | Token maps and theming utilities (`lightTokens`, `themeToVars`, …) |
+| `sve-ui/theme.css` | The stylesheet that registers all `--sve-*` variables              |
+
+## Requirements
+
+- Svelte `^5` (peer dependency)
+
+## Links
+
+- Docs: [sveui.org](https://sveui.org)
+- Source: [github.com/rodriabregu/sve-ui](https://github.com/rodriabregu/sve-ui)
+
+## License
+
+[MIT](https://github.com/rodriabregu/sve-ui/blob/main/LICENSE) © Rodrigo Abregu

--- a/packages/sve-ui/package.json
+++ b/packages/sve-ui/package.json
@@ -2,7 +2,7 @@
 	"name": "sve-ui",
 	"version": "0.2.0",
 	"type": "module",
-	"description": "Sve-UI is a collection of customizable UI components for Svelte applications. These components are designed to be easy to use and highly flexible, allowing developers to quickly build beautiful interfaces. Sve-UI includes buttons, forms, modals, and other commonly used UI elements, all built with Svelte's lightweight and efficient framework.",
+	"description": "Styled, accessible Svelte 5 components built on Bits UI. No Tailwind, no config — install, import, and theme with CSS variables. Light and dark out of the box.",
 	"author": "Rodrigo Abregu <me@rodriab.io> (https://rodriab.io/)",
 	"license": "MIT",
 	"homepage": "https://sveui.org/",


### PR DESCRIPTION
## What

Gives the freshly-published package a proper storefront.

- **`packages/sve-ui/README.md`** (new) — this is what npm renders. Pitch/wedge, install, quick start (with the real API: `theme.css` import, `Button` with `color`, `Dialog` namespace), component list, theming via `--sve-*` variables, exports table.
- **Root `README.md`** — rewritten as a monorepo overview + dev/release guide. The old one still described the pre-rewrite API (`onClick`) and the old layout-primitive components (Box/Center/Spacer).
- **Package description** sharpened to the wedge (no Tailwind, accessible, Bits UI, CSS-var themed).
- **Patch changeset** so the README reaches the npm page on the next release (0.2.0 was published without one — npm always includes README, but it has to be in the published tarball, i.e. the next version).

## Notes

`npm` always includes `README.md` regardless of the `files` field, so no `package.json` change was needed for it to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
