### PR TITLE
feat: Wave 3 form controls (Switch, Checkbox, RadioGroup) + docs polish

### DIFF
--- a/.changeset/wave3-form-controls.md
+++ b/.changeset/wave3-form-controls.md
@@ -1,0 +1,14 @@
+---
+'sve-ui': minor
+---
+
+Add Wave 3 form controls (batch 1), built on Bits UI:
+
+- **Switch** (`Switch.Root`) — accessible toggle with `sm`/`md`/`lg` sizes and
+  `bind:checked`.
+- **Checkbox** (`Checkbox.Root`) — checkbox with check / indeterminate indicators,
+  `sm`/`md`/`lg` sizes, `bind:checked` and `bind:indeterminate`.
+- **RadioGroup** (`RadioGroup.Root` + `RadioGroup.Item`) — radio group with a
+  selected-dot indicator and `bind:value`.
+
+All styled with `--sve-*` tokens, no Tailwind required.

--- a/apps/docs/src/app.html
+++ b/apps/docs/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
 		<meta name="viewport" content="width=device-width" />
 		%sveltekit.head%
 	</head>

--- a/apps/docs/src/lib/version.ts
+++ b/apps/docs/src/lib/version.ts
@@ -1,0 +1,8 @@
+import pkg from 'sve-ui/package.json';
+
+/**
+ * The live sve-ui package version, read from the package at build time.
+ * Updates automatically on every release (Vercel rebuilds the docs after a
+ * version bump), so the landing never shows a stale hardcoded version.
+ */
+export const SVE_UI_VERSION = `v${pkg.version}`;

--- a/apps/docs/src/routes/+layout.svelte
+++ b/apps/docs/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import '../app.css';
 	import { ThemeProvider } from 'sve-ui';
 	import type { Snippet } from 'svelte';
+	import { SVE_UI_VERSION } from '$lib/version';
 
 	interface Props {
 		children: Snippet;
@@ -9,7 +10,7 @@
 
 	let { children }: Props = $props();
 
-	const VERSION = 'v0.1.2';
+	const VERSION = SVE_UI_VERSION;
 	const REPO = 'https://github.com/rodriabregu/sve-ui';
 	const NPM = 'https://www.npmjs.com/package/sve-ui';
 

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -14,10 +14,11 @@
 		Popover,
 		ThemeProvider
 	} from 'sve-ui';
+	import { SVE_UI_VERSION } from '$lib/version';
 
 	const REPO = 'https://github.com/rodriabregu/sve-ui';
 	const NPM = 'https://www.npmjs.com/package/sve-ui';
-	const VERSION = 'v0.1.2';
+	const VERSION = SVE_UI_VERSION;
 
 	// --- Live theming sandbox state (scoped to the Theming section panel) ---
 	const ACCENTS = [
@@ -253,7 +254,7 @@
 			{@render panel('Avatar', undefined)}
 			<div class="flex items-center gap-3.5">
 				<Avatar.Root size="lg">
-					<Avatar.Image src="https://github.com/rodriabregu.png" alt="Rodrigo" />
+					<Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="Example user" />
 					<Avatar.Fallback>RA</Avatar.Fallback>
 				</Avatar.Root>
 				<Avatar.Root size="lg" shape="square">

--- a/apps/docs/src/routes/components/+page.svelte
+++ b/apps/docs/src/routes/components/+page.svelte
@@ -12,10 +12,16 @@
 		Dialog,
 		DropdownMenu,
 		Tooltip,
-		Popover
+		Popover,
+		Switch,
+		Checkbox,
+		RadioGroup
 	} from 'sve-ui';
 
 	let dialogOpen = $state(false);
+	let switchOn = $state(true);
+	let checkboxOn = $state(true);
+	let radioValue = $state('comfortable');
 </script>
 
 <svelte:head>
@@ -26,7 +32,7 @@
 <div class="max-w-4xl mx-auto px-6 py-10">
 	<Heading level={1} size="lg" class="mb-2">Components</Heading>
 	<Text size="lg" class="mb-10" style="opacity: 0.7;">
-		All 13 components with live examples. Use the dark mode toggle in the navbar to see theming in
+		All 16 components with live examples. Use the dark mode toggle in the navbar to see theming in
 		action.
 	</Text>
 
@@ -78,6 +84,58 @@
 				<Input variant="outline" size="lg" placeholder="Large input" />
 				<Input variant="outline" size="md" placeholder="Invalid input" invalid />
 			</div>
+		</div>
+	</section>
+
+	<!-- SECTION: Form controls -->
+	<section class="mb-14">
+		<Heading level={2} size="md" class="mb-6 pb-2 border-b" style="border-color: var(--sve-color-default-border);">
+			Form controls
+		</Heading>
+
+		<!-- Switch -->
+		<div class="mb-10">
+			<Heading level={3} size="sm" class="mb-1">Switch</Heading>
+			<Text size="sm" class="mb-4" style="opacity: 0.6;">size — bind:checked</Text>
+			<div class="flex flex-wrap items-center gap-4">
+				<Switch.Root bind:checked={switchOn} size="sm" />
+				<Switch.Root bind:checked={switchOn} size="md" />
+				<Switch.Root bind:checked={switchOn} size="lg" />
+				<Text size="sm" style="opacity: 0.6;">checked: {switchOn}</Text>
+			</div>
+		</div>
+
+		<!-- Checkbox -->
+		<div class="mb-10">
+			<Heading level={3} size="sm" class="mb-1">Checkbox</Heading>
+			<Text size="sm" class="mb-4" style="opacity: 0.6;">size — bind:checked + indeterminate</Text>
+			<div class="flex flex-wrap items-center gap-4">
+				<label class="flex items-center gap-2">
+					<Checkbox.Root bind:checked={checkboxOn} size="sm" />
+					<Text size="sm">Small</Text>
+				</label>
+				<label class="flex items-center gap-2">
+					<Checkbox.Root bind:checked={checkboxOn} size="md" />
+					<Text size="sm">Medium</Text>
+				</label>
+				<Checkbox.Root indeterminate size="md" />
+				<Text size="sm" style="opacity: 0.6;">checked: {checkboxOn}</Text>
+			</div>
+		</div>
+
+		<!-- Radio Group -->
+		<div class="mb-10">
+			<Heading level={3} size="sm" class="mb-1">RadioGroup</Heading>
+			<Text size="sm" class="mb-4" style="opacity: 0.6;">Root + Item — bind:value</Text>
+			<RadioGroup.Root bind:value={radioValue}>
+				{#each ['comfortable', 'compact', 'spacious'] as option (option)}
+					<label class="flex items-center gap-2">
+						<RadioGroup.Item value={option} />
+						<Text size="sm" class="capitalize">{option}</Text>
+					</label>
+				{/each}
+			</RadioGroup.Root>
+			<Text size="sm" class="mt-3" style="opacity: 0.6;">value: {radioValue}</Text>
 		</div>
 	</section>
 
@@ -150,15 +208,15 @@
 
 			<div class="flex flex-wrap items-center gap-4">
 				<Avatar.Root size="sm">
-					<Avatar.Image src="https://github.com/rodriabregu.png" alt="Rodrigo" />
+					<Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="Example user" />
 					<Avatar.Fallback>RA</Avatar.Fallback>
 				</Avatar.Root>
 				<Avatar.Root size="md">
-					<Avatar.Image src="https://github.com/rodriabregu.png" alt="Rodrigo" />
+					<Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="Example user" />
 					<Avatar.Fallback>RA</Avatar.Fallback>
 				</Avatar.Root>
 				<Avatar.Root size="lg">
-					<Avatar.Image src="https://github.com/rodriabregu.png" alt="Rodrigo" />
+					<Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="Example user" />
 					<Avatar.Fallback>RA</Avatar.Fallback>
 				</Avatar.Root>
 				<!-- Fallback only (no image) -->

--- a/apps/docs/static/favicon.svg
+++ b/apps/docs/static/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Sve·UI">
+  <rect width="32" height="32" rx="7" fill="#F56565" />
+  <text
+    x="16"
+    y="16.5"
+    text-anchor="middle"
+    dominant-baseline="central"
+    font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif"
+    font-size="20"
+    font-weight="800"
+    fill="#ffffff"
+  >S</text>
+</svg>

--- a/packages/sve-ui/README.md
+++ b/packages/sve-ui/README.md
@@ -71,6 +71,8 @@ without it):
 **Display & form** — `Button`, `Input`, `Card`, `Badge`, `Avatar`, `Spinner`,
 `Text`, `Heading`, `Alert`.
 
+**Form controls** (on Bits UI) — `Switch`, `Checkbox`, `RadioGroup`.
+
 **Overlays** (on Bits UI) — `Dialog`, `DropdownMenu`, `Tooltip`, `Popover`.
 
 Most components take `variant`, `color` and `size` props, e.g.:
@@ -82,9 +84,9 @@ Most components take `variant`, `color` and `size` props, e.g.:
 <Input variant="outline" size="md" placeholder="you@example.com" bind:value />
 ```
 
-Overlays (`Dialog`, `DropdownMenu`, `Tooltip`, `Popover`, plus `Avatar`, `Card`,
-`Alert`) are **namespaced** compositions — import the namespace and compose its
-parts (`Dialog.Root`, `Dialog.Trigger`, `Dialog.Content`, …).
+`Avatar`, `Card`, `Alert`, the overlays, and the form controls are **namespaced**
+compositions — import the namespace and compose its parts (`Dialog.Root`,
+`Dialog.Trigger`, `Dialog.Content`; `RadioGroup.Root`, `RadioGroup.Item`; …).
 
 ## Theming
 

--- a/packages/sve-ui/package.json
+++ b/packages/sve-ui/package.json
@@ -27,6 +27,7 @@
 			"svelte": "./dist/index.js",
 			"default": "./dist/index.js"
 		},
+		"./package.json": "./package.json",
 		"./theme": {
 			"types": "./dist/theme/index.d.ts",
 			"svelte": "./dist/theme/index.js",

--- a/packages/sve-ui/src/lib/components/Checkbox/CheckboxRoot.svelte
+++ b/packages/sve-ui/src/lib/components/Checkbox/CheckboxRoot.svelte
@@ -1,0 +1,95 @@
+<script module lang="ts">
+  export type Size = 'sm' | 'md' | 'lg';
+</script>
+
+<script lang="ts">
+  import { Checkbox } from 'bits-ui';
+  import type { ComponentProps } from 'svelte';
+
+  type BitsRootProps = ComponentProps<typeof Checkbox.Root>;
+
+  interface Props extends Omit<BitsRootProps, 'class' | 'children'> {
+    size?: Size;
+    class?: string;
+  }
+
+  let {
+    size = 'md',
+    checked = $bindable(false),
+    indeterminate = $bindable(false),
+    class: cls,
+    ...rest
+  }: Props = $props();
+
+  const className = $derived(
+    ['sve-checkbox', `sve-checkbox--${size}`, cls].filter(Boolean).join(' ')
+  );
+</script>
+
+<Checkbox.Root
+  bind:checked
+  bind:indeterminate
+  class={className}
+  data-slot="checkbox"
+  {...rest}
+>
+  {#snippet children({ checked, indeterminate })}
+    {#if indeterminate}
+      <svg class="sve-checkbox__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" aria-hidden="true">
+        <path d="M5 12h14" />
+      </svg>
+    {:else if checked}
+      <svg class="sve-checkbox__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M20 6 9 17l-5-5" />
+      </svg>
+    {/if}
+  {/snippet}
+</Checkbox.Root>
+
+<style>
+  :global(.sve-checkbox) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    padding: 0;
+    border: 1px solid var(--sve-color-default-border);
+    border-radius: var(--sve-radius-sm);
+    background-color: transparent;
+    color: var(--sve-color-primary-foreground);
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+  }
+
+  :global(.sve-checkbox[data-state='checked']),
+  :global(.sve-checkbox[data-state='indeterminate']) {
+    background-color: var(--sve-color-primary);
+    border-color: var(--sve-color-primary);
+  }
+
+  :global(.sve-checkbox:focus-visible) {
+    outline: 2px solid var(--sve-color-primary);
+    outline-offset: 2px;
+  }
+
+  :global(.sve-checkbox:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  :global(.sve-checkbox__icon) {
+    width: 80%;
+    height: 80%;
+  }
+
+  /* --- Sizes --- */
+  :global(.sve-checkbox--sm) { width: 1rem; height: 1rem; }
+  :global(.sve-checkbox--md) { width: 1.25rem; height: 1.25rem; }
+  :global(.sve-checkbox--lg) { width: 1.5rem; height: 1.5rem; }
+
+  @media (prefers-reduced-motion: reduce) {
+    :global(.sve-checkbox) {
+      transition: none;
+    }
+  }
+</style>

--- a/packages/sve-ui/src/lib/components/Checkbox/index.ts
+++ b/packages/sve-ui/src/lib/components/Checkbox/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Checkbox namespace — sve-ui styled wrapper over the bits-ui Checkbox primitive.
+ *
+ * Root: styled box + check/indeterminate indicator (Bits owns ARIA
+ * role="checkbox", keyboard, and state). `bind:checked` and `bind:indeterminate`
+ * are forwarded to the Bits root.
+ */
+
+export { default as Root, type Size as CheckboxSize } from './CheckboxRoot.svelte';

--- a/packages/sve-ui/src/lib/components/RadioGroup/RadioGroupItem.svelte
+++ b/packages/sve-ui/src/lib/components/RadioGroup/RadioGroupItem.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { RadioGroup } from 'bits-ui';
+  import type { ComponentProps } from 'svelte';
+
+  type BitsItemProps = ComponentProps<typeof RadioGroup.Item>;
+
+  interface Props extends Omit<BitsItemProps, 'class' | 'children'> {
+    class?: string;
+  }
+
+  let { class: cls, ...rest }: Props = $props();
+
+  const className = $derived(['sve-radio', cls].filter(Boolean).join(' '));
+</script>
+
+<RadioGroup.Item class={className} data-slot="radio-item" {...rest}>
+  {#snippet children({ checked })}
+    {#if checked}<span class="sve-radio__dot" data-slot="radio-dot"></span>{/if}
+  {/snippet}
+</RadioGroup.Item>
+
+<style>
+  :global(.sve-radio) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 1.25rem;
+    height: 1.25rem;
+    padding: 0;
+    border: 1px solid var(--sve-color-default-border);
+    border-radius: var(--sve-radius-full);
+    background-color: transparent;
+    cursor: pointer;
+    transition: border-color 0.15s ease;
+  }
+
+  :global(.sve-radio[data-state='checked']) {
+    border-color: var(--sve-color-primary);
+  }
+
+  :global(.sve-radio:focus-visible) {
+    outline: 2px solid var(--sve-color-primary);
+    outline-offset: 2px;
+  }
+
+  :global(.sve-radio:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  :global(.sve-radio__dot) {
+    width: 0.625rem;
+    height: 0.625rem;
+    border-radius: var(--sve-radius-full);
+    background-color: var(--sve-color-primary);
+  }
+</style>

--- a/packages/sve-ui/src/lib/components/RadioGroup/RadioGroupRoot.svelte
+++ b/packages/sve-ui/src/lib/components/RadioGroup/RadioGroupRoot.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { RadioGroup } from 'bits-ui';
+  import type { ComponentProps } from 'svelte';
+
+  type BitsRootProps = ComponentProps<typeof RadioGroup.Root>;
+
+  interface Props extends Omit<BitsRootProps, 'class'> {
+    class?: string;
+  }
+
+  let { value = $bindable(), class: cls, ...rest }: Props = $props();
+
+  const className = $derived(
+    ['sve-radio-group', cls].filter(Boolean).join(' ')
+  );
+</script>
+
+<RadioGroup.Root bind:value class={className} data-slot="radio-group" {...rest} />
+
+<style>
+  :global(.sve-radio-group) {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sve-space-2);
+  }
+
+  :global(.sve-radio-group[data-orientation='horizontal']) {
+    flex-direction: row;
+  }
+</style>

--- a/packages/sve-ui/src/lib/components/RadioGroup/index.ts
+++ b/packages/sve-ui/src/lib/components/RadioGroup/index.ts
@@ -1,0 +1,10 @@
+/**
+ * RadioGroup namespace — sve-ui styled wrappers over bits-ui RadioGroup.
+ *
+ * Root: styled group container; `bind:value` is forwarded to the Bits root
+ * (Bits owns ARIA role="radiogroup", roving focus, and keyboard navigation).
+ * Item: styled radio with a selected dot indicator. `value` is required.
+ */
+
+export { default as Root } from './RadioGroupRoot.svelte';
+export { default as Item } from './RadioGroupItem.svelte';

--- a/packages/sve-ui/src/lib/components/Switch/SwitchRoot.svelte
+++ b/packages/sve-ui/src/lib/components/Switch/SwitchRoot.svelte
@@ -1,0 +1,87 @@
+<script module lang="ts">
+  export type Size = 'sm' | 'md' | 'lg';
+</script>
+
+<script lang="ts">
+  import { Switch } from 'bits-ui';
+  import type { ComponentProps } from 'svelte';
+
+  type BitsRootProps = ComponentProps<typeof Switch.Root>;
+
+  interface Props extends Omit<BitsRootProps, 'class'> {
+    size?: Size;
+    class?: string;
+  }
+
+  let {
+    size = 'md',
+    checked = $bindable(false),
+    class: cls,
+    ...rest
+  }: Props = $props();
+
+  const className = $derived(
+    ['sve-switch', `sve-switch--${size}`, cls].filter(Boolean).join(' ')
+  );
+</script>
+
+<Switch.Root bind:checked class={className} data-slot="switch" {...rest}>
+  <Switch.Thumb class="sve-switch__thumb" data-slot="switch-thumb" />
+</Switch.Root>
+
+<style>
+  :global(.sve-switch) {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    padding: 2px;
+    border: none;
+    border-radius: var(--sve-radius-full);
+    background-color: var(--sve-color-default);
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+  }
+
+  :global(.sve-switch[data-state='checked']) {
+    background-color: var(--sve-color-primary);
+  }
+
+  :global(.sve-switch:focus-visible) {
+    outline: 2px solid var(--sve-color-primary);
+    outline-offset: 2px;
+  }
+
+  :global(.sve-switch:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  :global(.sve-switch__thumb) {
+    display: block;
+    border-radius: var(--sve-radius-full);
+    background-color: #ffffff;
+    box-shadow: var(--sve-shadow-sm);
+    transition: transform 0.15s ease;
+    transform: translateX(0);
+  }
+
+  /* --- Sizes (track height/width + thumb size + travel) --- */
+  :global(.sve-switch--sm) { width: 2rem; height: 1.25rem; }
+  :global(.sve-switch--sm .sve-switch__thumb) { width: 1rem; height: 1rem; }
+  :global(.sve-switch--sm[data-state='checked'] .sve-switch__thumb) { transform: translateX(0.75rem); }
+
+  :global(.sve-switch--md) { width: 2.5rem; height: 1.5rem; }
+  :global(.sve-switch--md .sve-switch__thumb) { width: 1.25rem; height: 1.25rem; }
+  :global(.sve-switch--md[data-state='checked'] .sve-switch__thumb) { transform: translateX(1rem); }
+
+  :global(.sve-switch--lg) { width: 3rem; height: 1.75rem; }
+  :global(.sve-switch--lg .sve-switch__thumb) { width: 1.5rem; height: 1.5rem; }
+  :global(.sve-switch--lg[data-state='checked'] .sve-switch__thumb) { transform: translateX(1.25rem); }
+
+  @media (prefers-reduced-motion: reduce) {
+    :global(.sve-switch),
+    :global(.sve-switch__thumb) {
+      transition: none;
+    }
+  }
+</style>

--- a/packages/sve-ui/src/lib/components/Switch/index.ts
+++ b/packages/sve-ui/src/lib/components/Switch/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Switch namespace — sve-ui styled wrapper over the bits-ui Switch primitive.
+ *
+ * Root: styled track + thumb (Bits owns ARIA role="switch", keyboard, state).
+ * `bind:checked` is forwarded to the Bits root.
+ */
+
+export { default as Root, type Size as SwitchSize } from './SwitchRoot.svelte';

--- a/packages/sve-ui/src/lib/index.ts
+++ b/packages/sve-ui/src/lib/index.ts
@@ -36,6 +36,15 @@ export * as Card from './components/Card/index.js';
 // Alert namespace
 export * as Alert from './components/Alert/index.js';
 
+// Switch namespace (composed over bits-ui)
+export * as Switch from './components/Switch/index.js';
+
+// Checkbox namespace (composed over bits-ui)
+export * as Checkbox from './components/Checkbox/index.js';
+
+// RadioGroup namespace (composed over bits-ui)
+export * as RadioGroup from './components/RadioGroup/index.js';
+
 // Button variant types
 export { buttonVariants } from './components/Button/Button.svelte';
 

--- a/packages/sve-ui/src/tests/Checkbox.test.ts
+++ b/packages/sve-ui/src/tests/Checkbox.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import CheckboxFixture from './CheckboxFixture.svelte';
+
+describe('Checkbox', () => {
+  it('renders a checkbox with the base class', () => {
+    const { container } = render(CheckboxFixture, { props: {} });
+    const el = container.querySelector('[data-slot="checkbox"]');
+    expect(el).not.toBeNull();
+    expect(el?.classList.contains('sve-checkbox')).toBe(true);
+  });
+
+  it('applies md size by default and sm when requested', () => {
+    const { container: a } = render(CheckboxFixture, { props: {} });
+    expect(a.querySelector('[data-slot="checkbox"]')?.classList.contains('sve-checkbox--md')).toBe(true);
+    const { container: b } = render(CheckboxFixture, { props: { size: 'sm' as const } });
+    expect(b.querySelector('[data-slot="checkbox"]')?.classList.contains('sve-checkbox--sm')).toBe(true);
+  });
+
+  it('exposes role="checkbox" (Bits UI a11y)', () => {
+    const { getByRole } = render(CheckboxFixture, { props: {} });
+    expect(getByRole('checkbox')).toBeTruthy();
+  });
+
+  it('is unchecked with no indicator initially', () => {
+    const { container, getByTestId } = render(CheckboxFixture, { props: {} });
+    const el = container.querySelector('[data-slot="checkbox"]');
+    expect(el?.getAttribute('data-state')).toBe('unchecked');
+    expect(container.querySelector('.sve-checkbox__icon')).toBeNull();
+    expect(getByTestId('state').textContent).toBe('false');
+  });
+
+  it('checks on click, shows the indicator, and reflects via bind:checked', async () => {
+    const { getByRole, getByTestId, container } = render(CheckboxFixture, { props: {} });
+    const el = getByRole('checkbox');
+    await fireEvent.click(el);
+    expect(el.getAttribute('data-state')).toBe('checked');
+    expect(container.querySelector('.sve-checkbox__icon')).not.toBeNull();
+    expect(getByTestId('state').textContent).toBe('true');
+  });
+});

--- a/packages/sve-ui/src/tests/CheckboxFixture.svelte
+++ b/packages/sve-ui/src/tests/CheckboxFixture.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import * as Checkbox from '$lib/components/Checkbox/index.js';
+
+  let { size }: { size?: 'sm' | 'md' | 'lg' } = $props();
+  let checked = $state(false);
+</script>
+
+<Checkbox.Root bind:checked {size} />
+<output data-testid="state">{checked}</output>

--- a/packages/sve-ui/src/tests/RadioGroup.test.ts
+++ b/packages/sve-ui/src/tests/RadioGroup.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import RadioGroupFixture from './RadioGroupFixture.svelte';
+
+describe('RadioGroup', () => {
+  it('renders a radiogroup with two radio items', () => {
+    const { container, getAllByRole } = render(RadioGroupFixture, { props: {} });
+    expect(container.querySelector('[data-slot="radio-group"]')?.classList.contains('sve-radio-group')).toBe(true);
+    expect(getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('has no selection initially (no dot indicator)', () => {
+    const { container, getByTestId } = render(RadioGroupFixture, { props: {} });
+    expect(container.querySelector('.sve-radio__dot')).toBeNull();
+    expect(getByTestId('value').textContent).toBe('');
+  });
+
+  it('selects an item on click and reflects via bind:value', async () => {
+    const { getAllByRole, getByTestId, container } = render(RadioGroupFixture, { props: {} });
+    const [first, second] = getAllByRole('radio');
+
+    await fireEvent.click(first);
+    expect(first.getAttribute('data-state')).toBe('checked');
+    expect(getByTestId('value').textContent).toBe('a');
+    expect(container.querySelectorAll('.sve-radio__dot')).toHaveLength(1);
+
+    await fireEvent.click(second);
+    expect(second.getAttribute('data-state')).toBe('checked');
+    expect(first.getAttribute('data-state')).toBe('unchecked');
+    expect(getByTestId('value').textContent).toBe('b');
+  });
+});

--- a/packages/sve-ui/src/tests/RadioGroupFixture.svelte
+++ b/packages/sve-ui/src/tests/RadioGroupFixture.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import * as RadioGroup from '$lib/components/RadioGroup/index.js';
+
+  let value = $state('');
+</script>
+
+<RadioGroup.Root bind:value>
+  <RadioGroup.Item value="a" />
+  <RadioGroup.Item value="b" />
+</RadioGroup.Root>
+<output data-testid="value">{value}</output>

--- a/packages/sve-ui/src/tests/Switch.test.ts
+++ b/packages/sve-ui/src/tests/Switch.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import SwitchFixture from './SwitchFixture.svelte';
+
+describe('Switch', () => {
+  it('renders a switch with the base class', () => {
+    const { container } = render(SwitchFixture, { props: {} });
+    const el = container.querySelector('[data-slot="switch"]');
+    expect(el).not.toBeNull();
+    expect(el?.classList.contains('sve-switch')).toBe(true);
+  });
+
+  it('applies md size by default', () => {
+    const { container } = render(SwitchFixture, { props: {} });
+    const el = container.querySelector('[data-slot="switch"]');
+    expect(el?.classList.contains('sve-switch--md')).toBe(true);
+  });
+
+  it('applies the sm size', () => {
+    const { container } = render(SwitchFixture, { props: { size: 'sm' as const } });
+    const el = container.querySelector('[data-slot="switch"]');
+    expect(el?.classList.contains('sve-switch--sm')).toBe(true);
+  });
+
+  it('exposes role="switch" (Bits UI a11y)', () => {
+    const { getByRole } = render(SwitchFixture, { props: {} });
+    expect(getByRole('switch')).toBeTruthy();
+  });
+
+  it('is unchecked initially', () => {
+    const { container, getByTestId } = render(SwitchFixture, { props: {} });
+    const el = container.querySelector('[data-slot="switch"]');
+    expect(el?.getAttribute('data-state')).toBe('unchecked');
+    expect(getByTestId('state').textContent).toBe('false');
+  });
+
+  it('toggles checked on click and reflects via bind:checked', async () => {
+    const { getByRole, getByTestId } = render(SwitchFixture, { props: {} });
+    const el = getByRole('switch');
+    await fireEvent.click(el);
+    expect(el.getAttribute('data-state')).toBe('checked');
+    expect(getByTestId('state').textContent).toBe('true');
+  });
+});

--- a/packages/sve-ui/src/tests/SwitchFixture.svelte
+++ b/packages/sve-ui/src/tests/SwitchFixture.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import * as Switch from '$lib/components/Switch/index.js';
+
+  let { size }: { size?: 'sm' | 'md' | 'lg' } = $props();
+  let checked = $state(false);
+</script>
+
+<Switch.Root bind:checked {size} />
+<output data-testid="state">{checked}</output>


### PR DESCRIPTION
## What

Wave 3 (batch 1) form controls, plus three landing/docs polish items requested for this release.

### New components (`sve-ui`)

Built on Bits UI, styled entirely with `--sve-*` tokens (no Tailwind):

- **Switch** (`Switch.Root`) — toggle, `sm`/`md`/`lg`, `bind:checked`.
- **Checkbox** (`Checkbox.Root`) — check + indeterminate indicators, `sm`/`md`/`lg`, `bind:checked` and `bind:indeterminate`.
- **RadioGroup** (`RadioGroup.Root` + `RadioGroup.Item`) — selected-dot indicator, `bind:value`.

Each ships with tests + fixtures (167 tests pass). Documented on the components page (now 16 components). Minor changeset included.

### Docs polish

- **Dynamic version chip** — the navbar/landing/CTA version is now read from the `sve-ui` package at build time (exposed via a new `./package.json` export), so it auto-updates on every release instead of being hardcoded.
- **Placeholder avatar** — swapped the personal GitHub avatar in the Avatar examples for a random placeholder (`i.pravatar.cc`).
- **Favicon** — added an S-on-red-square `favicon.svg` matching the navbar brand mark.

## Verification

`build`, `lint`, `check`, `test` all green (167 tests; svelte-check 0 errors; docs builds with adapter-vercel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
