### PR TITLE
docs: add CONTRIBUTING, Code of Conduct, and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: Report a bug in Sve·UI
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for reporting! A minimal reproduction makes fixes much faster.
+  - type: input
+    id: version
+    attributes:
+      label: sve-ui version
+      placeholder: e.g. 0.2.1
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Steps to reproduce, or a link to a minimal repro (Svelte REPL, StackBlitz, or repo).
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - A component
+        - Theming / CSS variables
+        - Types
+        - Build / packaging
+        - Other
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Svelte / SvelteKit version, browser, and OS.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://sveui.org
+    about: Component usage, theming, and live examples.
+  - name: npm package
+    url: https://www.npmjs.com/package/sve-ui
+    about: Install instructions and published versions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest a component, prop, or improvement
+labels: ['enhancement']
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that's hard or impossible with Sve·UI today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? Sketch an API if you can.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've tried.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## What & why
+
+<!-- One or two sentences: what this changes and why it matters. -->
+
+## Review path
+
+<!-- Where should a reviewer start? What's intentionally out of scope?
+     Link the previous/next PR if this is part of a chain. -->
+
+## Checklist
+
+- [ ] Tests added/updated and passing (`pnpm test`)
+- [ ] `pnpm lint && pnpm check && pnpm build` all green
+- [ ] Changeset included for user-facing changes (`pnpm changeset`)
+- [ ] Docs updated (README / components page) if the public API changed
+- [ ] No Tailwind / config required in consumer projects (styles via `--sve-*`)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Code of Conduct
+
+This project adopts the **Contributor Covenant**, version 2.1, as its Code of
+Conduct. The full text is available at:
+
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+## In short
+
+We are committed to a welcoming, harassment-free experience for everyone. Be
+respectful, assume good intent, and keep discussion constructive. Behavior that
+the Contributor Covenant defines as unacceptable is not tolerated.
+
+## Reporting
+
+To report abusive, harassing, or otherwise unacceptable behavior, contact the
+maintainer privately at **me@rodriab.io**. Reports are handled confidentially.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to Sve·UI
+
+Thanks for helping! This guide takes you from clone to merged PR.
+
+## Quick path
+
+1. Fork and clone, then `pnpm install` (pnpm is required — `npm`/`yarn` are blocked).
+2. Branch off `main`.
+3. Make your change **and a test** for it.
+4. Run `pnpm changeset` to describe the change (see [Changesets](#changesets)).
+5. Verify locally — all green:
+   ```sh
+   pnpm build && pnpm lint && pnpm check && pnpm test
+   ```
+6. Open a PR to `main`. CI runs the same four checks.
+
+## Setup
+
+| Requirement | Version                                        |
+| ----------- | ---------------------------------------------- |
+| Node        | `>= 22.14`                                     |
+| pnpm        | `>= 11` (Corepack-pinned via `packageManager`) |
+
+Repo layout and dev scripts are documented in the [README](./README.md#repository).
+
+## Project conventions
+
+| Area            | Convention                                                                                            |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| Package manager | **pnpm only.** A `preinstall` guard rejects `npm`/`yarn`.                                             |
+| Styling         | Scoped Svelte `<style>` reading `--sve-*` CSS variables. **No Tailwind** in the library.              |
+| Components      | Svelte 5 runes. Interactive/overlay components wrap [Bits UI](https://bits-ui.com) for accessibility. |
+| Linting         | Hybrid: **Oxlint** for `.ts`/`.js`, **eslint-plugin-svelte** for `.svelte`.                           |
+| Commits         | [Conventional Commits](https://www.conventionalcommits.org) (`feat:`, `fix:`, `docs:`, …).            |
+| Tests           | Vitest + `@testing-library/svelte`. One test per component (render, props, variants, behavior).       |
+
+## Adding a component
+
+1. Create `packages/sve-ui/src/lib/components/<Name>/` with the component (+ a namespace `index.ts` for composed/Bits-backed components).
+2. Style it with `--sve-*` tokens only — light and dark must both work.
+3. Export it from `packages/sve-ui/src/lib/index.ts`.
+4. Add a test + fixture under `packages/sve-ui/src/tests/`.
+5. Document it on the docs `components` page and in the package README.
+
+## Changesets
+
+Anything user-facing needs a changeset so the version bumps and the changelog updates:
+
+```sh
+pnpm changeset      # pick patch / minor / major + write a summary
+```
+
+Commit the generated file with your change. Docs-only or internal-tooling changes that don't affect the published package don't need one.
+
+## Submitting a PR
+
+- [ ] Tests added/updated and passing
+- [ ] `pnpm lint && pnpm check && pnpm build` all green
+- [ ] A changeset is included (for user-facing changes)
+- [ ] Docs updated (README / components page) if the public API changed
+
+A maintainer reviews, then merges. On merge to `main`, Changesets opens a **"Version Packages"** PR; merging that publishes to npm automatically.
+
+## Reporting bugs & requesting features
+
+Use the [issue templates](https://github.com/rodriabregu/sve-ui/issues/new/choose). Please include a minimal reproduction for bugs.
+
+## Code of Conduct
+
+This project follows the [Code of Conduct](./CODE_OF_CONDUCT.md). By participating, you agree to uphold it.


### PR DESCRIPTION
## What

Adds the GitHub community health files for the now-public, published package.

- **CONTRIBUTING.md** — quick-path (clone → change → changeset → verify → PR), setup table, project conventions, an "adding a component" guide, and a submit checklist.
- **CODE_OF_CONDUCT.md** — adopts the Contributor Covenant 2.1 by reference (link + reporting contact), no full text pasted.
- **.github/PULL_REQUEST_TEMPLATE.md** — what/why, review path, and a verification checklist (tests, lint/check/build, changeset, docs, no-Tailwind).
- **.github/ISSUE_TEMPLATE/** — `bug_report.yml` and `feature_request.yml` forms + `config.yml` (blank issues off; links to docs and npm).

All written against the `cognitive-doc-design` rubric: lead with the answer, quick path first, chunked sections, checklists over prose.

No changeset — these are repo-level files, not part of the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
