### PR TITLE
feat(docs): redesign /components as sidebar docs with per-component pages

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -165,7 +165,15 @@ Ship in prioritized waves; each component = tests + a11y + docs page + Storybook
 - [ ] **Wave 2 (overlays, Bits UI):** Dialog/Modal, Dropdown Menu, Tooltip, Popover, Toast
 - [ ] **Wave 3 (forms, Bits UI):** Select, Combobox, Checkbox, Radio Group, Switch, Slider, Tabs, Accordion
 - [ ] **Wave 4 (advanced):** Date Picker, Command/Search, Table, Pagination, Toast region
+- [ ] **Sidebar (composable app-shell nav):** `Sidebar.Root/Header/Content/Group/Item/Footer` + collapsible state + mobile behavior + context provider. Precedent: shadcn-svelte ships one (HeroUI/Bits UI do not). NOTE: the docs `/components` sidebar we built is **app composition** (coupled to the docs registry + routing + soon/new tags), NOT this primitive. Build the generic component first, then **rebuild the docs sidebar on top of it (dogfood)**. One of the larger components — its own item, not a "while we're at it".
 - [ ] Minimal internal layout layer (Box/Stack/Flex) — building blocks, not headline
+
+#### Coverage principle — anchor the roadmap to the Bits UI catalog
+Because every styled component wraps a Bits UI primitive, **the Bits UI catalog IS our low-effort backlog**: anything Bits already ships is a styling job, not a behavior/a11y job. Bits UI provides 41 primitives; map every one to a `sve-ui` component before reaching for custom builds.
+
+- [ ] **Remaining Bits UI primitives to wrap (surfaced as `soon` in /components):** Alert Dialog, Aspect Ratio, Calendar, Collapsible, Date Field, Date Picker, Label, Link Preview (hover card), Menubar, Meter, Navigation Menu, PIN Input, Rating Group, Toggle, Toolbar, Range Calendar, Date/Time Range variants
+- [ ] **Custom (non-Bits) components still needed:** Textarea (native, styled), Toast region (external dep — svelte-sonner vs melt-ui), Table (custom), Skeleton, Breadcrumb, Sheet (styled Dialog), Pagination, Carousel (embla), Stack/Flex/Separator already noted
+- [ ] **Gap found 2026-06-21:** Textarea and Alert Dialog were missing from the plan entirely — added. Textarea is the most-expected form control after Input.
 
 ### Phase 2 — Testing
 - [ ] Vitest + `@testing-library/svelte` (+ jsdom/browser); delete the `1+2` test

--- a/apps/docs/src/lib/docs/DocPage.svelte
+++ b/apps/docs/src/lib/docs/DocPage.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	export interface TocEntry {
+		id: string;
+		label: string;
+	}
+
+	interface Props {
+		group: string;
+		name: string;
+		description: string;
+		toc?: TocEntry[];
+		children: Snippet;
+	}
+
+	let { group, name, description, toc = [], children }: Props = $props();
+</script>
+
+<svelte:head>
+	<title>{name} — Sve·UI</title>
+	<meta name="description" content={description} />
+</svelte:head>
+
+<div class="docpage">
+	<article class="docpage__main">
+		<nav class="docpage__crumb" aria-label="Breadcrumb">
+			<a href="/components">Components</a>
+			<span class="docpage__crumb-sep">/</span>
+			<span>{group}</span>
+		</nav>
+
+		<h1 class="docpage__title">{name}</h1>
+		<p class="docpage__lede">{description}</p>
+
+		<div class="docpage__body">
+			{@render children()}
+		</div>
+	</article>
+
+	{#if toc.length}
+		<aside class="docpage__toc">
+			<span class="docpage__toc-label">On this page</span>
+			<nav>
+				{#each toc as t (t.id)}
+					<a href={`#${t.id}`} class="docpage__toc-link">{t.label}</a>
+				{/each}
+			</nav>
+		</aside>
+	{/if}
+</div>
+
+<style>
+	.docpage {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr);
+		gap: 48px;
+	}
+
+	@media (min-width: 1100px) {
+		.docpage {
+			grid-template-columns: minmax(0, 1fr) 180px;
+		}
+	}
+
+	.docpage__main {
+		min-width: 0;
+		padding: 40px 4px 80px;
+	}
+
+	.docpage__crumb {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		font-size: 13px;
+		color: var(--doc-fg-subtle);
+		margin-bottom: 14px;
+	}
+	.docpage__crumb a {
+		color: var(--doc-fg-muted);
+		text-decoration: none;
+	}
+	.docpage__crumb a:hover {
+		color: var(--doc-fg);
+	}
+	.docpage__crumb-sep {
+		opacity: 0.6;
+	}
+
+	.docpage__title {
+		font-size: 38px;
+		font-weight: 800;
+		letter-spacing: -0.03em;
+		line-height: 1.08;
+		color: var(--doc-fg);
+		margin: 0;
+	}
+
+	.docpage__lede {
+		margin: 12px 0 0;
+		max-width: 620px;
+		font-size: 17px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+
+	.docpage__body {
+		margin-top: 36px;
+	}
+
+	.docpage__toc {
+		display: none;
+	}
+
+	@media (min-width: 1100px) {
+		.docpage__toc {
+			display: block;
+			align-self: start;
+			position: sticky;
+			top: 88px;
+			padding-top: 40px;
+		}
+	}
+
+	.docpage__toc-label {
+		display: block;
+		font-size: 11px;
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--doc-fg-subtle);
+		margin-bottom: 12px;
+	}
+
+	.docpage__toc nav {
+		display: flex;
+		flex-direction: column;
+		gap: 9px;
+		border-left: 1px solid var(--doc-border);
+	}
+
+	.docpage__toc-link {
+		padding-left: 14px;
+		font-size: 13px;
+		color: var(--doc-fg-muted);
+		text-decoration: none;
+		transition: color 120ms ease;
+	}
+	.docpage__toc-link:hover {
+		color: var(--doc-fg);
+	}
+</style>

--- a/apps/docs/src/lib/docs/Preview.svelte
+++ b/apps/docs/src/lib/docs/Preview.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		/** Source shown under the Code tab. */
+		code: string;
+		/** Live demo rendered under the Preview tab. */
+		children: Snippet;
+		/** Vertically center the demo (default) vs. top-align it. */
+		align?: 'center' | 'start';
+	}
+
+	let { code, children, align = 'center' }: Props = $props();
+
+	let tab = $state<'preview' | 'code'>('preview');
+	let copied = $state(false);
+	let resetTimer: ReturnType<typeof setTimeout> | undefined;
+
+	async function copy() {
+		if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+		try {
+			await navigator.clipboard.writeText(code);
+			copied = true;
+			clearTimeout(resetTimer);
+			resetTimer = setTimeout(() => (copied = false), 1600);
+		} catch {
+			/* clipboard blocked — no-op */
+		}
+	}
+</script>
+
+<div class="preview">
+	<div class="preview__bar">
+		<div class="preview__tabs" role="tablist">
+			<button
+				role="tab"
+				aria-selected={tab === 'preview'}
+				class="preview__tab"
+				class:is-active={tab === 'preview'}
+				onclick={() => (tab = 'preview')}>Preview</button
+			>
+			<button
+				role="tab"
+				aria-selected={tab === 'code'}
+				class="preview__tab"
+				class:is-active={tab === 'code'}
+				onclick={() => (tab = 'code')}>Code</button
+			>
+		</div>
+		<button class="preview__copy" onclick={copy} aria-label="Copy code">
+			{#if copied}
+				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5" /></svg>
+				Copied
+			{:else}
+				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2" /><path d="M5 15V5a2 2 0 0 1 2-2h10" /></svg>
+				Copy
+			{/if}
+		</button>
+	</div>
+
+	{#if tab === 'preview'}
+		<div class="preview__canvas" class:is-start={align === 'start'}>
+			{@render children()}
+		</div>
+	{:else}
+		<pre class="preview__code doc-mono"><code>{code}</code></pre>
+	{/if}
+</div>
+
+<style>
+	.preview {
+		border: 1px solid var(--doc-border);
+		border-radius: 14px;
+		background: var(--doc-surface);
+		overflow: hidden;
+		box-shadow: var(--doc-shadow);
+	}
+
+	.preview__bar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0 10px 0 14px;
+		border-bottom: 1px solid var(--doc-border);
+		background: var(--doc-surface-2);
+	}
+
+	.preview__tabs {
+		display: flex;
+		gap: 2px;
+	}
+
+	.preview__tab {
+		position: relative;
+		padding: 12px 6px;
+		margin-right: 12px;
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: 13.5px;
+		font-weight: 600;
+		color: var(--doc-fg-subtle);
+		transition: color 120ms ease;
+	}
+	.preview__tab:hover {
+		color: var(--doc-fg-muted);
+	}
+	.preview__tab.is-active {
+		color: var(--doc-fg);
+	}
+	.preview__tab.is-active::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 12px;
+		bottom: -1px;
+		height: 2px;
+		border-radius: 2px;
+		background: var(--sve-color-primary);
+	}
+
+	.preview__copy {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 6px 10px;
+		border-radius: 8px;
+		border: 1px solid var(--doc-border-2);
+		background: var(--doc-surface);
+		color: var(--doc-fg-muted);
+		font-size: 12.5px;
+		font-weight: 600;
+		cursor: pointer;
+		transition: color 120ms ease, border-color 120ms ease;
+	}
+	.preview__copy:hover {
+		color: var(--doc-fg);
+		border-color: var(--doc-fg-subtle);
+	}
+
+	.preview__canvas {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-wrap: wrap;
+		gap: 14px;
+		min-height: 160px;
+		padding: 32px 24px;
+		background-image: radial-gradient(var(--doc-dot) 1px, transparent 1px);
+		background-size: 22px 22px;
+	}
+	.preview__canvas.is-start {
+		align-items: flex-start;
+		justify-content: flex-start;
+	}
+
+	.preview__code {
+		margin: 0;
+		padding: 18px 20px;
+		overflow-x: auto;
+		font-size: 13px;
+		line-height: 1.7;
+		color: #e6e6ec;
+		background: var(--doc-code-bg);
+	}
+	.preview__code code {
+		font-family: inherit;
+		white-space: pre;
+	}
+</style>

--- a/apps/docs/src/lib/docs/PropsTable.svelte
+++ b/apps/docs/src/lib/docs/PropsTable.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+	export interface PropRow {
+		prop: string;
+		type: string;
+		default?: string;
+		description?: string;
+	}
+
+	interface Props {
+		rows: PropRow[];
+	}
+
+	let { rows }: Props = $props();
+</script>
+
+<div class="props">
+	<table class="props__table">
+		<thead>
+			<tr>
+				<th>Prop</th>
+				<th>Type</th>
+				<th>Default</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each rows as row (row.prop)}
+				<tr>
+					<td>
+						<code class="props__name doc-mono">{row.prop}</code>
+						{#if row.description}
+							<span class="props__desc">{row.description}</span>
+						{/if}
+					</td>
+					<td><code class="props__type doc-mono">{row.type}</code></td>
+					<td>
+						{#if row.default}
+							<code class="props__default doc-mono">{row.default}</code>
+						{:else}
+							<span class="props__dash">—</span>
+						{/if}
+					</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+</div>
+
+<style>
+	.props {
+		border: 1px solid var(--doc-border);
+		border-radius: 14px;
+		overflow: hidden;
+		background: var(--doc-surface);
+	}
+
+	.props__table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 13.5px;
+	}
+
+	.props__table thead th {
+		text-align: left;
+		padding: 12px 18px;
+		font-size: 11px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--doc-fg-subtle);
+		background: var(--doc-surface-2);
+		border-bottom: 1px solid var(--doc-border);
+	}
+
+	.props__table tbody tr {
+		border-bottom: 1px solid var(--doc-border);
+	}
+	.props__table tbody tr:last-child {
+		border-bottom: none;
+	}
+
+	.props__table td {
+		padding: 14px 18px;
+		vertical-align: top;
+		color: var(--doc-fg-muted);
+	}
+
+	.props__name {
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--doc-fg);
+	}
+	.props__desc {
+		display: block;
+		margin-top: 4px;
+		font-size: 12.5px;
+		color: var(--doc-fg-subtle);
+	}
+	.props__type {
+		font-size: 12.5px;
+		color: var(--doc-primary-text);
+	}
+	.props__default {
+		font-size: 12.5px;
+		color: var(--doc-fg-muted);
+	}
+	.props__dash {
+		color: var(--doc-fg-subtle);
+	}
+</style>

--- a/apps/docs/src/lib/docs/registry.ts
+++ b/apps/docs/src/lib/docs/registry.ts
@@ -1,0 +1,130 @@
+/**
+ * Central component registry — single source of truth for the docs sidebar,
+ * the /components index grid, and per-component page metadata.
+ *
+ * `ready: true` means a dedicated /components/<slug> page exists. Items that are
+ * not ready yet render as dimmed "soon" entries instead of dead 404 links.
+ */
+
+export type ComponentStatus = 'stable' | 'new';
+
+export interface ComponentMeta {
+	slug: string;
+	name: string;
+	blurb: string;
+	status?: ComponentStatus;
+	ready?: boolean;
+}
+
+export interface ComponentGroup {
+	label: string;
+	items: ComponentMeta[];
+}
+
+export const componentGroups: ComponentGroup[] = [
+	{
+		label: 'Display',
+		items: [
+			{ slug: 'avatar', name: 'Avatar', blurb: 'Image with graceful fallback.', ready: true },
+			{ slug: 'badge', name: 'Badge', blurb: 'Compact status and count labels.', ready: true },
+			{ slug: 'card', name: 'Card', blurb: 'Surface container for grouped content.', ready: true },
+			{ slug: 'heading', name: 'Heading', blurb: 'Semantic, sized display titles.', ready: true },
+			{ slug: 'text', name: 'Text', blurb: 'Body copy with size and tone.', ready: true },
+			{ slug: 'skeleton', name: 'Skeleton', blurb: 'Loading placeholder for content.' }
+		]
+	},
+	{
+		label: 'Forms',
+		items: [
+			{ slug: 'button', name: 'Button', blurb: 'Primary action. Variants, tones and sizes.', ready: true },
+			{ slug: 'input', name: 'Input', blurb: 'Single-line text field with states.', ready: true },
+			{ slug: 'checkbox', name: 'Checkbox', blurb: 'Boolean choice, accessible by default.', status: 'new', ready: true },
+			{ slug: 'radio-group', name: 'Radio Group', blurb: 'Single choice from a set.', status: 'new', ready: true },
+			{ slug: 'switch', name: 'Switch', blurb: 'On/off toggle control.', status: 'new', ready: true },
+			{ slug: 'select', name: 'Select', blurb: 'Listbox for picking one option.', status: 'new', ready: true },
+			{ slug: 'combobox', name: 'Combobox', blurb: 'Filterable autocomplete select.', status: 'new', ready: true },
+			{ slug: 'slider', name: 'Slider', blurb: 'Pick a value along a range.', status: 'new', ready: true },
+			{ slug: 'textarea', name: 'Textarea', blurb: 'Multi-line text field.' },
+			{ slug: 'label', name: 'Label', blurb: 'Accessible form label.' },
+			{ slug: 'toggle', name: 'Toggle', blurb: 'Two-state toggle button.' },
+			{ slug: 'toggle-group', name: 'Toggle Group', blurb: 'Grouped toggle buttons.' },
+			{ slug: 'calendar', name: 'Calendar', blurb: 'Date grid for selection.' },
+			{ slug: 'date-field', name: 'Date Field', blurb: 'Segmented date input.' },
+			{ slug: 'date-picker', name: 'Date Picker', blurb: 'Calendar-based date selection.' },
+			{ slug: 'pin-input', name: 'PIN Input', blurb: 'One-time-code / PIN entry.' },
+			{ slug: 'rating-group', name: 'Rating Group', blurb: 'Star rating input.' }
+		]
+	},
+	{
+		label: 'Feedback',
+		items: [
+			{ slug: 'alert', name: 'Alert', blurb: 'Inline status and messaging.', ready: true },
+			{ slug: 'spinner', name: 'Spinner', blurb: 'Indeterminate loading indicator.', ready: true },
+			{ slug: 'toast', name: 'Toast', blurb: 'Transient, stacked notifications.' },
+			{ slug: 'progress', name: 'Progress', blurb: 'Determinate progress bar.' },
+			{ slug: 'meter', name: 'Meter', blurb: 'Bounded scalar measurement.' }
+		]
+	},
+	{
+		label: 'Navigation',
+		items: [
+			{ slug: 'tabs', name: 'Tabs', blurb: 'Switch between related panels.', status: 'new', ready: true },
+			{ slug: 'accordion', name: 'Accordion', blurb: 'Collapsible disclosure sections.', status: 'new', ready: true },
+			{ slug: 'sidebar', name: 'Sidebar', blurb: 'Composable app-shell navigation.' },
+			{ slug: 'breadcrumb', name: 'Breadcrumb', blurb: 'Hierarchical page trail.' },
+			{ slug: 'navigation-menu', name: 'Navigation Menu', blurb: 'Top-level nav with menus.' },
+			{ slug: 'menubar', name: 'Menubar', blurb: 'Desktop-style menu bar.' },
+			{ slug: 'collapsible', name: 'Collapsible', blurb: 'Single expand/collapse region.' },
+			{ slug: 'toolbar', name: 'Toolbar', blurb: 'Grouped controls container.' }
+		]
+	},
+	{
+		label: 'Overlays',
+		items: [
+			{ slug: 'dialog', name: 'Dialog', blurb: 'Modal with focus trap and overlay.', ready: true },
+			{ slug: 'dropdown-menu', name: 'Dropdown Menu', blurb: 'Contextual action menu.', ready: true },
+			{ slug: 'popover', name: 'Popover', blurb: 'Floating content anchored to a trigger.', ready: true },
+			{ slug: 'tooltip', name: 'Tooltip', blurb: 'Hover/focus hint text.', ready: true },
+			{ slug: 'alert-dialog', name: 'Alert Dialog', blurb: 'Confirmation modal.' },
+			{ slug: 'command', name: 'Command', blurb: 'Command palette / fuzzy search menu.' },
+			{ slug: 'sheet', name: 'Sheet', blurb: 'Side drawer panel.' },
+			{ slug: 'context-menu', name: 'Context Menu', blurb: 'Right-click action menu.' },
+			{ slug: 'link-preview', name: 'Link Preview', blurb: 'Hover card preview.' }
+		]
+	},
+	{
+		label: 'Data',
+		items: [
+			{ slug: 'table', name: 'Table', blurb: 'Sortable, styled data table.' },
+			{ slug: 'pagination', name: 'Pagination', blurb: 'Page-by-page navigation.' }
+		]
+	},
+	{
+		label: 'Layout',
+		items: [
+			{ slug: 'stack', name: 'Stack', blurb: 'Vertical spacing primitive.' },
+			{ slug: 'flex', name: 'Flex', blurb: 'Flexbox layout primitive.' },
+			{ slug: 'separator', name: 'Separator', blurb: 'Visual or semantic divider.' },
+			{ slug: 'scroll-area', name: 'Scroll Area', blurb: 'Styled custom scroll container.' },
+			{ slug: 'aspect-ratio', name: 'Aspect Ratio', blurb: 'Constrain content ratio.' }
+		]
+	},
+	{
+		label: 'Utilities',
+		items: [{ slug: 'code', name: 'Code', blurb: 'Copyable code block.', status: 'new', ready: true }]
+	}
+];
+
+/** Flat lookup for page metadata and prev/next nav. */
+export const componentBySlug: Record<string, ComponentMeta & { group: string }> =
+	Object.fromEntries(
+		componentGroups.flatMap((g) => g.items.map((it) => [it.slug, { ...it, group: g.label }]))
+	);
+
+export const totalComponents = componentGroups.reduce((n, g) => n + g.items.length, 0);
+
+/** Components with a live page — the count shown in the index headline. */
+export const readyComponents = componentGroups.reduce(
+	(n, g) => n + g.items.filter((it) => it.ready).length,
+	0
+);

--- a/apps/docs/src/routes/components/+layout.svelte
+++ b/apps/docs/src/routes/components/+layout.svelte
@@ -1,0 +1,297 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { afterNavigate } from '$app/navigation';
+	import type { Snippet } from 'svelte';
+	import { componentGroups } from '$lib/docs/registry';
+
+	let { children }: { children: Snippet } = $props();
+
+	let query = $state('');
+	/** Mobile-only: the nav panel is collapsed by default; ignored at >= 900px. */
+	let menuOpen = $state(false);
+
+	let filtered = $derived(
+		componentGroups
+			.map((g) => ({
+				...g,
+				items: g.items.filter((it) =>
+					it.name.toLowerCase().includes(query.trim().toLowerCase())
+				)
+			}))
+			.filter((g) => g.items.length > 0)
+	);
+
+	function isActive(slug: string): boolean {
+		return page.url.pathname === `/components/${slug}`;
+	}
+
+	/** Mobile: collapse the panel once navigation to a component page completes. */
+	afterNavigate(() => (menuOpen = false));
+</script>
+
+<div class="shell">
+	<aside class="shell__sidebar">
+		<button
+			class="shell__toggle"
+			onclick={() => (menuOpen = !menuOpen)}
+			aria-expanded={menuOpen}
+			aria-controls="components-nav"
+		>
+			<span>Browse components</span>
+			<svg
+				class="shell__toggle-chevron"
+				class:is-open={menuOpen}
+				width="16"
+				height="16"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2.2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg
+			>
+		</button>
+
+		<div id="components-nav" class="shell__panel" class:is-open={menuOpen}>
+			<div class="shell__search">
+				<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.3-4.3" /></svg>
+				<input
+					type="search"
+					placeholder="Search components…"
+					bind:value={query}
+					aria-label="Search components"
+				/>
+			</div>
+
+			<nav class="shell__nav">
+				{#each filtered as group (group.label)}
+					<div class="shell__group">
+						<span class="shell__group-label">{group.label}</span>
+						{#each group.items as item (item.slug)}
+							{#if item.ready}
+								<a
+									href={`/components/${item.slug}`}
+									class="shell__link"
+									class:is-active={isActive(item.slug)}
+									aria-current={isActive(item.slug) ? 'page' : undefined}
+								>
+									{item.name}
+									{#if item.status === 'new'}<span class="shell__tag">new</span>{/if}
+								</a>
+							{:else}
+								<span class="shell__link is-soon">
+									{item.name}
+									<span class="shell__soon">soon</span>
+								</span>
+							{/if}
+						{/each}
+					</div>
+				{:else}
+					<p class="shell__empty">No components match “{query}”.</p>
+				{/each}
+			</nav>
+		</div>
+	</aside>
+
+	<div class="shell__content">
+		{@render children()}
+	</div>
+</div>
+
+<style>
+	.shell {
+		max-width: 1400px;
+		margin: 0 auto;
+		padding: 0 24px;
+	}
+
+	@media (min-width: 900px) {
+		.shell {
+			display: grid;
+			grid-template-columns: 248px minmax(0, 1fr);
+			gap: 40px;
+			padding: 0 28px;
+		}
+	}
+
+	.shell__sidebar {
+		padding: 16px 0;
+	}
+
+	@media (min-width: 900px) {
+		.shell__sidebar {
+			position: sticky;
+			top: 64px;
+			align-self: start;
+			height: calc(100vh - 64px);
+			overflow-y: auto;
+			padding: 28px 10px 40px 0;
+			border-right: 1px solid var(--doc-border);
+			/* Thin, themed scrollbar instead of the chunky OS default. */
+			scrollbar-width: thin;
+			scrollbar-color: var(--doc-border-2) transparent;
+		}
+		.shell__sidebar::-webkit-scrollbar {
+			width: 7px;
+		}
+		.shell__sidebar::-webkit-scrollbar-track {
+			background: transparent;
+		}
+		.shell__sidebar::-webkit-scrollbar-thumb {
+			background: var(--doc-border);
+			border-radius: 999px;
+		}
+		.shell__sidebar:hover::-webkit-scrollbar-thumb {
+			background: var(--doc-border-2);
+		}
+	}
+
+	/* --- Mobile disclosure toggle (hidden on desktop) --- */
+	.shell__toggle {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		padding: 12px 16px;
+		border: 1px solid var(--doc-border-2);
+		border-radius: 11px;
+		background: var(--doc-surface);
+		color: var(--doc-fg);
+		font-family: var(--sve-font-family-sans);
+		font-size: 14.5px;
+		font-weight: 600;
+		cursor: pointer;
+	}
+	.shell__toggle-chevron {
+		color: var(--doc-fg-subtle);
+		transition: transform 160ms ease;
+	}
+	.shell__toggle-chevron.is-open {
+		transform: rotate(180deg);
+	}
+
+	@media (min-width: 900px) {
+		.shell__toggle {
+			display: none;
+		}
+	}
+
+	/* --- Nav panel: collapsed on mobile, always shown on desktop --- */
+	.shell__panel {
+		display: none;
+		margin-top: 12px;
+		padding-bottom: 8px;
+	}
+	.shell__panel.is-open {
+		display: block;
+	}
+
+	@media (min-width: 900px) {
+		.shell__panel {
+			display: block;
+			margin-top: 0;
+		}
+	}
+
+	.shell__search {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 9px 12px;
+		border: 1px solid var(--doc-border-2);
+		border-radius: 10px;
+		background: var(--doc-surface);
+		color: var(--doc-fg-subtle);
+		margin-bottom: 22px;
+	}
+	.shell__search:focus-within {
+		border-color: var(--doc-fg-subtle);
+	}
+	.shell__search input {
+		flex: 1;
+		min-width: 0;
+		border: none;
+		outline: none;
+		background: none;
+		font-family: var(--sve-font-family-sans);
+		font-size: 13.5px;
+		color: var(--doc-fg);
+	}
+	.shell__search input::placeholder {
+		color: var(--doc-fg-subtle);
+	}
+
+	.shell__nav {
+		display: flex;
+		flex-direction: column;
+		gap: 22px;
+	}
+
+	.shell__group {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+	}
+
+	.shell__group-label {
+		font-size: 11px;
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--doc-fg-subtle);
+		padding: 0 12px 8px;
+	}
+
+	.shell__link {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 7px 12px;
+		border-radius: 8px;
+		font-size: 14px;
+		font-weight: 500;
+		color: var(--doc-fg-muted);
+		text-decoration: none;
+		transition: background-color 120ms ease, color 120ms ease;
+	}
+	.shell__link:hover:not(.is-soon) {
+		color: var(--doc-fg);
+		background: var(--doc-surface);
+	}
+	.shell__link.is-active {
+		color: var(--doc-primary-text);
+		background: color-mix(in srgb, var(--sve-color-primary) 12%, transparent);
+		font-weight: 600;
+	}
+
+	.shell__link.is-soon {
+		color: var(--doc-fg-subtle);
+		cursor: default;
+		justify-content: space-between;
+	}
+
+	.shell__tag,
+	.shell__soon {
+		font-size: 9.5px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		padding: 2px 6px;
+		border-radius: 999px;
+	}
+	.shell__tag {
+		background: color-mix(in srgb, var(--sve-color-primary) 16%, transparent);
+		color: var(--doc-primary-text);
+	}
+	.shell__soon {
+		background: var(--doc-surface-2);
+		color: var(--doc-fg-subtle);
+	}
+
+	.shell__empty {
+		font-size: 13.5px;
+		color: var(--doc-fg-subtle);
+		padding: 0 12px;
+	}
+</style>

--- a/apps/docs/src/routes/components/+page.svelte
+++ b/apps/docs/src/routes/components/+page.svelte
@@ -1,550 +1,176 @@
 <script lang="ts">
-	import {
-		Button,
-		Badge,
-		Text,
-		Heading,
-		Avatar,
-		Spinner,
-		Card,
-		Alert,
-		Input,
-		Dialog,
-		DropdownMenu,
-		Tooltip,
-		Popover,
-		Switch,
-		Checkbox,
-		RadioGroup,
-		Tabs,
-		Accordion,
-		Code,
-		Select,
-		Combobox,
-		Slider
-	} from 'sve-ui';
+	import { componentGroups, readyComponents, totalComponents } from '$lib/docs/registry';
 
-	let dialogOpen = $state(false);
-	let switchOn = $state(true);
-	let checkboxOn = $state(true);
-	let radioValue = $state('comfortable');
-	let tabValue = $state('account');
-	let selectValue = $state('');
-	let comboValue = $state('');
-	let sliderValue = $state(40);
-
-	const fruits = ['Apple', 'Banana', 'Cherry', 'Mango'];
-	let comboQuery = $state('');
-	let filteredFruits = $derived(
-		fruits.filter((f) => f.toLowerCase().includes(comboQuery.toLowerCase()))
-	);
+	const comingSoon = totalComponents - readyComponents;
 </script>
 
 <svelte:head>
-	<title>Components — Sve-UI</title>
-	<meta name="description" content="Every Sve-UI component with live examples." />
+	<title>Components — Sve·UI</title>
+	<meta
+		name="description"
+		content="Every Sve·UI component — display, forms, feedback, navigation and overlays. Styled, accessible, zero config."
+	/>
 </svelte:head>
 
-<div class="max-w-4xl mx-auto px-6 py-10">
-	<Heading level={1} size="lg" class="mb-2">Components</Heading>
-	<Text size="lg" class="mb-10" style="opacity: 0.7;">
-		Every component with live examples. Use the dark mode toggle in the navbar to see theming in
-		action.
-	</Text>
+<div class="index">
+	<header class="index__head">
+		<span class="doc-eyebrow">{readyComponents} components · {comingSoon} on the way</span>
+		<h1 class="index__title">Components</h1>
+		<p class="index__lede">
+			Every component is fully styled and accessible out of the box — built on Bits UI, themed with
+			CSS variables, and ready to drop in. Pick one to see live previews, code and props. Items
+			marked <span class="index__soon-inline">soon</span> are on the roadmap.
+		</p>
+	</header>
 
-	<!-- SECTION: Forms -->
-	<section class="mb-14">
-		<Heading level={2} size="md" class="mb-6 pb-2 border-b" style="border-color: var(--sve-color-default-border);">
-			Forms
-		</Heading>
-
-		<!-- Button -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Button</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">variant × color × size</Text>
-
-			<div class="space-y-4">
-				<div class="flex flex-wrap gap-3">
-					<Button variant="solid" color="primary">Primary</Button>
-					<Button variant="solid" color="secondary">Secondary</Button>
-					<Button variant="solid" color="success">Success</Button>
-					<Button variant="solid" color="warning">Warning</Button>
-					<Button variant="solid" color="danger">Danger</Button>
-					<Button variant="solid" color="default">Default</Button>
-				</div>
-				<div class="flex flex-wrap gap-3">
-					<Button variant="outline" color="primary">Outline</Button>
-					<Button variant="ghost" color="primary">Ghost</Button>
-					<Button variant="flat" color="primary">Flat</Button>
-				</div>
-				<div class="flex flex-wrap items-center gap-3">
-					<Button variant="solid" color="primary" size="sm">Small</Button>
-					<Button variant="solid" color="primary" size="md">Medium</Button>
-					<Button variant="solid" color="primary" size="lg">Large</Button>
-				</div>
-				<div class="flex flex-wrap gap-3">
-					<Button variant="solid" color="primary" disabled>Disabled</Button>
-				</div>
-			</div>
-		</div>
-
-		<!-- Input -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Input</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">variant × size × invalid state</Text>
-
-			<div class="flex flex-col gap-3 max-w-sm">
-				<Input variant="outline" size="md" placeholder="Outline input" />
-				<Input variant="filled" size="md" placeholder="Filled input" />
-				<Input variant="outline" size="sm" placeholder="Small input" />
-				<Input variant="outline" size="lg" placeholder="Large input" />
-				<Input variant="outline" size="md" placeholder="Invalid input" invalid />
-			</div>
-		</div>
-	</section>
-
-	<!-- SECTION: Form controls -->
-	<section class="mb-14">
-		<Heading level={2} size="md" class="mb-6 pb-2 border-b" style="border-color: var(--sve-color-default-border);">
-			Form controls
-		</Heading>
-
-		<!-- Switch -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Switch</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">size — bind:checked</Text>
-			<div class="flex flex-wrap items-center gap-4">
-				<Switch.Root bind:checked={switchOn} size="sm" />
-				<Switch.Root bind:checked={switchOn} size="md" />
-				<Switch.Root bind:checked={switchOn} size="lg" />
-				<Text size="sm" style="opacity: 0.6;">checked: {switchOn}</Text>
-			</div>
-		</div>
-
-		<!-- Checkbox -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Checkbox</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">size — bind:checked + indeterminate</Text>
-			<div class="flex flex-wrap items-center gap-4">
-				<label class="flex items-center gap-2">
-					<Checkbox.Root bind:checked={checkboxOn} size="sm" />
-					<Text size="sm">Small</Text>
-				</label>
-				<label class="flex items-center gap-2">
-					<Checkbox.Root bind:checked={checkboxOn} size="md" />
-					<Text size="sm">Medium</Text>
-				</label>
-				<Checkbox.Root indeterminate size="md" />
-				<Text size="sm" style="opacity: 0.6;">checked: {checkboxOn}</Text>
-			</div>
-		</div>
-
-		<!-- Radio Group -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">RadioGroup</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">Root + Item — bind:value</Text>
-			<RadioGroup.Root bind:value={radioValue}>
-				{#each ['comfortable', 'compact', 'spacious'] as option (option)}
-					<label class="flex items-center gap-2">
-						<RadioGroup.Item value={option} />
-						<Text size="sm" class="capitalize">{option}</Text>
-					</label>
+	{#each componentGroups as group (group.label)}
+		<section class="index__group">
+			<h2 class="index__group-title">{group.label}</h2>
+			<div class="index__grid">
+				{#each group.items as item (item.slug)}
+					{#if item.ready}
+						<a href={`/components/${item.slug}`} class="card">
+							<div class="card__top">
+								<span class="card__name">{item.name}</span>
+								{#if item.status === 'new'}<span class="card__tag">new</span>{/if}
+							</div>
+							<p class="card__blurb">{item.blurb}</p>
+							<span class="card__cta">
+								View
+								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
+							</span>
+						</a>
+					{:else}
+						<div class="card is-soon">
+							<div class="card__top">
+								<span class="card__name">{item.name}</span>
+								<span class="card__soon">soon</span>
+							</div>
+							<p class="card__blurb">{item.blurb}</p>
+						</div>
+					{/if}
 				{/each}
-			</RadioGroup.Root>
-			<Text size="sm" class="mt-3" style="opacity: 0.6;">value: {radioValue}</Text>
-		</div>
-
-		<!-- Slider -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Slider</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">value · min · max · step</Text>
-			<div class="max-w-sm">
-				<Slider type="single" value={sliderValue} onValueChange={(v) => (sliderValue = v as number)} max={100} step={1} />
-				<Text size="sm" class="mt-3" style="opacity: 0.6;">value: {sliderValue}</Text>
 			</div>
-		</div>
-
-		<!-- Select -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Select</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">Root + Trigger + Content + Item — bind:value</Text>
-			<div class="max-w-xs">
-				<Select.Root type="single" bind:value={selectValue}>
-					<Select.Trigger>{selectValue || 'Pick a fruit'}</Select.Trigger>
-					<Select.Content>
-						{#each fruits as fruit (fruit)}
-							<Select.Item value={fruit} label={fruit}>{fruit}</Select.Item>
-						{/each}
-					</Select.Content>
-				</Select.Root>
-				<Text size="sm" class="mt-3" style="opacity: 0.6;">value: {selectValue}</Text>
-			</div>
-		</div>
-
-		<!-- Combobox -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Combobox</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">Root + Input + Content + Item — type to filter</Text>
-			<div class="max-w-xs">
-				<Combobox.Root type="single" bind:value={comboValue}>
-					<Combobox.Input placeholder="Search fruit…" oninput={(e) => (comboQuery = e.currentTarget.value)} />
-					<Combobox.Content>
-						{#each filteredFruits as fruit (fruit)}
-							<Combobox.Item value={fruit} label={fruit}>{fruit}</Combobox.Item>
-						{/each}
-					</Combobox.Content>
-				</Combobox.Root>
-				<Text size="sm" class="mt-3" style="opacity: 0.6;">value: {comboValue}</Text>
-			</div>
-		</div>
-	</section>
-
-	<!-- SECTION: Display -->
-	<section class="mb-14">
-		<Heading level={2} size="md" class="mb-6 pb-2 border-b" style="border-color: var(--sve-color-default-border);">
-			Display
-		</Heading>
-
-		<!-- Text -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Text</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">as × size × weight × color × align</Text>
-
-			<div class="flex flex-col gap-2">
-				<Text size="lg">Large text — size lg</Text>
-				<Text size="md">Medium text — size md (default)</Text>
-				<Text size="sm" style="opacity: 0.6;">Small text — size sm</Text>
-				<Text weight="bold" color="primary">Bold primary text</Text>
-				<Text weight="medium" color="success">Medium success text</Text>
-				<Text as="code" size="sm" color="default">Inline code element</Text>
-			</div>
-		</div>
-
-		<!-- Heading -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Heading</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">level × size × weight × color</Text>
-
-			<div class="flex flex-col gap-2">
-				<Heading level={1} size="lg">Heading level 1 — lg</Heading>
-				<Heading level={2} size="md">Heading level 2 — md</Heading>
-				<Heading level={3} size="sm">Heading level 3 — sm</Heading>
-				<Heading level={4} color="primary">Heading level 4 — primary</Heading>
-				<Heading level={5} color="secondary" weight="medium">Heading 5 — secondary medium</Heading>
-			</div>
-		</div>
-
-		<!-- Badge -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Badge</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">variant × color × size</Text>
-
-			<div class="space-y-3">
-				<div class="flex flex-wrap gap-2">
-					<Badge color="primary">Primary</Badge>
-					<Badge color="secondary">Secondary</Badge>
-					<Badge color="success">Success</Badge>
-					<Badge color="warning">Warning</Badge>
-					<Badge color="danger">Danger</Badge>
-					<Badge color="default">Default</Badge>
-				</div>
-				<div class="flex flex-wrap gap-2">
-					<Badge color="primary" variant="subtle">Subtle</Badge>
-					<Badge color="success" variant="outline">Outline</Badge>
-					<Badge color="danger" variant="solid">Solid</Badge>
-				</div>
-				<div class="flex flex-wrap items-center gap-2">
-					<Badge color="primary" size="sm">Small</Badge>
-					<Badge color="primary" size="md">Medium</Badge>
-					<Badge color="primary" size="lg">Large</Badge>
-				</div>
-			</div>
-		</div>
-
-		<!-- Avatar -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Avatar</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">size × shape — Image + Fallback</Text>
-
-			<div class="flex flex-wrap items-center gap-4">
-				<Avatar.Root size="sm">
-					<Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="Example user" />
-					<Avatar.Fallback>RA</Avatar.Fallback>
-				</Avatar.Root>
-				<Avatar.Root size="md">
-					<Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="Example user" />
-					<Avatar.Fallback>RA</Avatar.Fallback>
-				</Avatar.Root>
-				<Avatar.Root size="lg">
-					<Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="Example user" />
-					<Avatar.Fallback>RA</Avatar.Fallback>
-				</Avatar.Root>
-				<!-- Fallback only (no image) -->
-				<Avatar.Root size="md" shape="square">
-					<Avatar.Fallback>SQ</Avatar.Fallback>
-				</Avatar.Root>
-				<Avatar.Root size="md">
-					<Avatar.Fallback>PF</Avatar.Fallback>
-				</Avatar.Root>
-			</div>
-		</div>
-
-		<!-- Spinner -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Spinner</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">size × color</Text>
-
-			<div class="flex flex-wrap items-center gap-6">
-				<Spinner size="sm" color="primary" />
-				<Spinner size="md" color="success" />
-				<Spinner size="lg" color="warning" />
-				<Spinner size="md" color="danger" />
-				<Spinner size="md" color="default" />
-			</div>
-		</div>
-
-		<!-- Card -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Card</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">variant × padding — Header + Content + Footer</Text>
-
-			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-				<Card.Root variant="elevated">
-					<Card.Header>
-						<Heading level={4} size="sm">Elevated card</Heading>
-					</Card.Header>
-					<Card.Content>
-						<Text size="sm">Card content goes here. Supports Header, Content, and Footer sections.</Text>
-					</Card.Content>
-					<Card.Footer>
-						<Button variant="solid" color="primary" size="sm">Action</Button>
-					</Card.Footer>
-				</Card.Root>
-
-				<Card.Root variant="outlined">
-					<Card.Header>
-						<Heading level={4} size="sm">Outline card</Heading>
-					</Card.Header>
-					<Card.Content>
-						<Text size="sm">Outline variant with a visible border. No drop shadow.</Text>
-					</Card.Content>
-					<Card.Footer>
-						<Button variant="outline" color="default" size="sm">Cancel</Button>
-					</Card.Footer>
-				</Card.Root>
-			</div>
-		</div>
-	</section>
-
-	<!-- SECTION: Feedback -->
-	<section class="mb-14">
-		<Heading level={2} size="md" class="mb-6 pb-2 border-b" style="border-color: var(--sve-color-default-border);">
-			Feedback
-		</Heading>
-
-		<!-- Alert -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Alert</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">color × variant — subtle / solid / outline</Text>
-
-			<div class="flex flex-col gap-3">
-				<Alert.Root color="success" variant="subtle">
-					<Alert.Title>Success</Alert.Title>
-					<Alert.Description>Your data has been saved successfully.</Alert.Description>
-				</Alert.Root>
-				<Alert.Root color="warning" variant="subtle">
-					<Alert.Title>Warning</Alert.Title>
-					<Alert.Description>Please review before submitting.</Alert.Description>
-				</Alert.Root>
-				<Alert.Root color="danger" variant="solid">
-					<Alert.Title>Error</Alert.Title>
-					<Alert.Description>Something went wrong. Please try again.</Alert.Description>
-				</Alert.Root>
-				<Alert.Root color="primary" variant="outline">
-					<Alert.Title>Info</Alert.Title>
-					<Alert.Description>New components are available in this release.</Alert.Description>
-				</Alert.Root>
-			</div>
-		</div>
-	</section>
-
-	<!-- SECTION: Overlays -->
-	<section class="mb-14">
-		<Heading level={2} size="md" class="mb-6 pb-2 border-b" style="border-color: var(--sve-color-default-border);">
-			Overlays
-		</Heading>
-
-		<!-- Dialog -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Dialog</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">Modal dialog — focus-trapped, WAI-ARIA compliant</Text>
-
-			<Dialog.Root bind:open={dialogOpen}>
-				<Dialog.Trigger>
-					{#snippet child({ props })}
-						<Button variant="solid" color="primary" {...props}>Open Dialog</Button>
-					{/snippet}
-				</Dialog.Trigger>
-				<Dialog.Overlay />
-				<Dialog.Content>
-					<Dialog.Title>Example Dialog</Dialog.Title>
-					<Dialog.Description>
-						This dialog is built on bits-ui for full WAI-ARIA compliance with focus trapping and
-						keyboard navigation.
-					</Dialog.Description>
-					<div class="mt-4 flex gap-2 justify-end">
-						<Dialog.Close>
-							{#snippet child({ props })}
-								<Button variant="outline" color="default" size="sm" {...props}>Cancel</Button>
-							{/snippet}
-						</Dialog.Close>
-						<Button variant="solid" color="primary" size="sm" onclick={() => (dialogOpen = false)}>
-							Confirm
-						</Button>
-					</div>
-				</Dialog.Content>
-			</Dialog.Root>
-		</div>
-
-		<!-- Tooltip -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Tooltip</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">Hover to reveal</Text>
-
-			<Tooltip.Provider>
-				<div class="flex flex-wrap gap-4">
-					<Tooltip.Root>
-						<Tooltip.Trigger>
-							{#snippet child({ props })}
-								<Button variant="outline" color="default" size="sm" {...props}>Hover me</Button>
-							{/snippet}
-						</Tooltip.Trigger>
-						<Tooltip.Content>
-							<Text size="sm">Tooltip content here</Text>
-						</Tooltip.Content>
-					</Tooltip.Root>
-
-					<Tooltip.Root>
-						<Tooltip.Trigger>
-							{#snippet child({ props })}
-								<Badge color="primary" {...props}>Badge with tooltip</Badge>
-							{/snippet}
-						</Tooltip.Trigger>
-						<Tooltip.Content>
-							<Text size="sm">Tooltips work on any element</Text>
-						</Tooltip.Content>
-					</Tooltip.Root>
-				</div>
-			</Tooltip.Provider>
-		</div>
-
-		<!-- Popover -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Popover</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">Click to toggle rich content panel</Text>
-
-			<Popover.Root>
-				<Popover.Trigger>
-					{#snippet child({ props })}
-						<Button variant="outline" color="primary" {...props}>Open Popover</Button>
-					{/snippet}
-				</Popover.Trigger>
-				<Popover.Content>
-					<Heading level={4} size="sm" class="mb-2">Popover content</Heading>
-					<Text size="sm">
-						Popovers are great for secondary actions, filters, or contextual info panels. They are
-						fully accessible and keyboard-navigable.
-					</Text>
-					<div class="mt-3">
-						<Popover.Close>
-							{#snippet child({ props })}
-								<Button variant="ghost" color="default" size="sm" {...props}>Close</Button>
-							{/snippet}
-						</Popover.Close>
-					</div>
-				</Popover.Content>
-			</Popover.Root>
-		</div>
-
-		<!-- DropdownMenu -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">DropdownMenu</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">Keyboard-navigable menu</Text>
-
-			<DropdownMenu.Root>
-				<DropdownMenu.Trigger>
-					{#snippet child({ props })}
-						<Button variant="solid" color="default" {...props}>
-							Options ▾
-						</Button>
-					{/snippet}
-				</DropdownMenu.Trigger>
-				<DropdownMenu.Content>
-					<DropdownMenu.Item>
-						Profile
-					</DropdownMenu.Item>
-					<DropdownMenu.Item>
-						Settings
-					</DropdownMenu.Item>
-					<DropdownMenu.Separator />
-					<DropdownMenu.Item>
-						Sign out
-					</DropdownMenu.Item>
-				</DropdownMenu.Content>
-			</DropdownMenu.Root>
-		</div>
-	</section>
-
-	<!-- SECTION: Navigation & content -->
-	<section class="mb-14">
-		<Heading level={2} size="md" class="mb-6 pb-2 border-b" style="border-color: var(--sve-color-default-border);">
-			Navigation & content
-		</Heading>
-
-		<!-- Tabs -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Tabs</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">Root + List + Trigger + Content — bind:value</Text>
-			<Tabs.Root bind:value={tabValue}>
-				<Tabs.List>
-					<Tabs.Trigger value="account">Account</Tabs.Trigger>
-					<Tabs.Trigger value="password">Password</Tabs.Trigger>
-					<Tabs.Trigger value="team">Team</Tabs.Trigger>
-				</Tabs.List>
-				<Tabs.Content value="account"><Text size="sm">Manage your account details.</Text></Tabs.Content>
-				<Tabs.Content value="password"><Text size="sm">Change your password here.</Text></Tabs.Content>
-				<Tabs.Content value="team"><Text size="sm">Invite and manage team members.</Text></Tabs.Content>
-			</Tabs.Root>
-		</div>
-
-		<!-- Accordion -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Accordion</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">Root + Item + Header + Trigger + Content — single / multiple</Text>
-			<Accordion.Root type="single">
-				<Accordion.Item value="a">
-					<Accordion.Header>
-						<Accordion.Trigger>Is it accessible?</Accordion.Trigger>
-					</Accordion.Header>
-					<Accordion.Content>Yes — built on Bits UI with full WAI-ARIA support and keyboard navigation.</Accordion.Content>
-				</Accordion.Item>
-				<Accordion.Item value="b">
-					<Accordion.Header>
-						<Accordion.Trigger>Does it need Tailwind?</Accordion.Trigger>
-					</Accordion.Header>
-					<Accordion.Content>No. Styles ship with the package; theme everything via CSS variables.</Accordion.Content>
-				</Accordion.Item>
-			</Accordion.Root>
-		</div>
-
-		<!-- Code -->
-		<div class="mb-10">
-			<Heading level={3} size="sm" class="mb-1">Code</Heading>
-			<Text size="sm" class="mb-4" style="opacity: 0.6;">code + label + copy-to-clipboard</Text>
-			<Code
-				label="App.svelte"
-				code={`import { Button } from 'sve-ui';\n\n<Button color="primary">Ship it</Button>`}
-			/>
-		</div>
-	</section>
+		</section>
+	{/each}
 </div>
+
+<style>
+	.index {
+		padding: 40px 4px 90px;
+	}
+
+	.index__head {
+		max-width: 640px;
+		margin-bottom: 44px;
+	}
+	.index__title {
+		font-size: 40px;
+		font-weight: 800;
+		letter-spacing: -0.03em;
+		line-height: 1.06;
+		color: var(--doc-fg);
+		margin: 10px 0 0;
+	}
+	.index__lede {
+		margin: 14px 0 0;
+		font-size: 17px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.index__soon-inline {
+		font-size: 11px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		padding: 2px 6px;
+		border-radius: 999px;
+		background: var(--doc-surface-2);
+		color: var(--doc-fg-subtle);
+		vertical-align: middle;
+	}
+
+	.index__group {
+		margin-bottom: 40px;
+	}
+	.index__group-title {
+		font-size: 13px;
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--doc-fg-subtle);
+		margin: 0 0 16px;
+	}
+
+	.index__grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+		gap: 14px;
+	}
+
+	.card {
+		display: flex;
+		flex-direction: column;
+		padding: 18px 18px 16px;
+		border: 1px solid var(--doc-border);
+		border-radius: 14px;
+		background: var(--doc-surface);
+		text-decoration: none;
+		transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
+	}
+	.card:not(.is-soon):hover {
+		border-color: color-mix(in srgb, var(--sve-color-primary) 45%, var(--doc-border));
+		transform: translateY(-2px);
+		box-shadow: var(--doc-shadow);
+	}
+	.card.is-soon {
+		opacity: 0.55;
+	}
+
+	.card__top {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-bottom: 6px;
+	}
+	.card__name {
+		font-size: 15px;
+		font-weight: 700;
+		letter-spacing: -0.01em;
+		color: var(--doc-fg);
+	}
+	.card__blurb {
+		flex: 1;
+		margin: 0;
+		font-size: 13px;
+		line-height: 1.5;
+		color: var(--doc-fg-muted);
+	}
+	.card__cta {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		margin-top: 14px;
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--doc-primary-text);
+	}
+
+	.card__tag,
+	.card__soon {
+		font-size: 9.5px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		padding: 2px 6px;
+		border-radius: 999px;
+	}
+	.card__tag {
+		background: color-mix(in srgb, var(--sve-color-primary) 16%, transparent);
+		color: var(--doc-primary-text);
+	}
+	.card__soon {
+		background: var(--doc-surface-2);
+		color: var(--doc-fg-subtle);
+	}
+</style>

--- a/apps/docs/src/routes/components/accordion/+page.svelte
+++ b/apps/docs/src/routes/components/accordion/+page.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+	import { Accordion } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.accordion;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'multiple', label: 'Multiple' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{ prop: 'type', type: `'single' | 'multiple'`, default: `'single'`, description: 'Single allows one open item at a time; multiple allows many.' },
+		{ prop: 'value', type: 'string | string[]', description: 'Controlled open item(s). Use bind:value for two-way binding.' },
+		{ prop: 'onValueChange', type: '(value: string & string[]) => void', description: 'Called when the open item(s) change.' },
+		{ prop: 'disabled', type: 'boolean', default: 'false', description: 'Disables all triggers in the accordion.' },
+		{ prop: 'loop', type: 'boolean', default: 'true', description: 'Keyboard focus loops from last trigger back to first.' },
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root.' },
+		{ prop: 'children', type: 'Snippet', description: 'Compose Accordion.Item blocks inside.' }
+	];
+
+	const usageCode = `<script>
+  import { Accordion } from 'sve-ui';
+<\/script>
+
+<Accordion.Root type="single">
+  <Accordion.Item value="a">
+    <Accordion.Header>
+      <Accordion.Trigger>Is it accessible?</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>
+      Yes — built on Bits UI with full WAI-ARIA support and keyboard navigation.
+    </Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="b">
+    <Accordion.Header>
+      <Accordion.Trigger>Does it need Tailwind?</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>
+      No. Styles ship with the package; theme everything via CSS variables.
+    </Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="c">
+    <Accordion.Header>
+      <Accordion.Trigger>Can I animate it?</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>
+      Yes. Target the data-state attribute on Content for CSS transitions.
+    </Accordion.Content>
+  </Accordion.Item>
+</Accordion.Root>`;
+
+	const multipleCode = `<Accordion.Root type="multiple">
+  <Accordion.Item value="a">
+    <Accordion.Header>
+      <Accordion.Trigger>First panel</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>Both panels can be open at the same time.</Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="b">
+    <Accordion.Header>
+      <Accordion.Trigger>Second panel</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content>Opening one does not close the other.</Accordion.Content>
+  </Accordion.Item>
+</Accordion.Root>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Import the namespace and compose <code class="ic">Accordion.Root</code>,
+			<code class="ic">Accordion.Item</code>, <code class="ic">Accordion.Header</code>,
+			<code class="ic">Accordion.Trigger</code>, and <code class="ic">Accordion.Content</code>.
+			The <code class="ic">type</code> prop controls whether one or many items can be open at once.
+		</p>
+		<Preview code={usageCode} align="start">
+			<div style="width: 100%; max-width: 480px;">
+				<Accordion.Root type="single">
+					<Accordion.Item value="a">
+						<Accordion.Header>
+							<Accordion.Trigger>Is it accessible?</Accordion.Trigger>
+						</Accordion.Header>
+						<Accordion.Content>
+							Yes — built on Bits UI with full WAI-ARIA support and keyboard navigation.
+						</Accordion.Content>
+					</Accordion.Item>
+					<Accordion.Item value="b">
+						<Accordion.Header>
+							<Accordion.Trigger>Does it need Tailwind?</Accordion.Trigger>
+						</Accordion.Header>
+						<Accordion.Content>
+							No. Styles ship with the package; theme everything via CSS variables.
+						</Accordion.Content>
+					</Accordion.Item>
+					<Accordion.Item value="c">
+						<Accordion.Header>
+							<Accordion.Trigger>Can I animate it?</Accordion.Trigger>
+						</Accordion.Header>
+						<Accordion.Content>
+							Yes. Target the <code class="ic">data-state</code> attribute on Content for CSS transitions.
+						</Accordion.Content>
+					</Accordion.Item>
+				</Accordion.Root>
+			</div>
+		</Preview>
+	</section>
+
+	<section id="multiple" class="sec">
+		<h2 class="sec__h">Multiple</h2>
+		<p class="sec__p">
+			Set <code class="ic">type="multiple"</code> to allow several items to stay open simultaneously.
+			Each item's open state is independent.
+		</p>
+		<Preview code={multipleCode} align="start">
+			<div style="width: 100%; max-width: 480px;">
+				<Accordion.Root type="multiple">
+					<Accordion.Item value="a">
+						<Accordion.Header>
+							<Accordion.Trigger>First panel</Accordion.Trigger>
+						</Accordion.Header>
+						<Accordion.Content>Both panels can be open at the same time.</Accordion.Content>
+					</Accordion.Item>
+					<Accordion.Item value="b">
+						<Accordion.Header>
+							<Accordion.Trigger>Second panel</Accordion.Trigger>
+						</Accordion.Header>
+						<Accordion.Content>Opening one does not close the other.</Accordion.Content>
+					</Accordion.Item>
+				</Accordion.Root>
+			</div>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Props for <code class="ic">Accordion.Root</code>. Each
+			<code class="ic">Accordion.Item</code> requires a unique <code class="ic">value</code> string
+			that pairs its <code class="ic">Trigger</code> with its <code class="ic">Content</code>.
+			All parts accept <code class="ic">class</code> for custom overrides.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/accordion/+page.svelte
+++ b/apps/docs/src/routes/components/accordion/+page.svelte
@@ -27,7 +27,7 @@
 
 	const usageCode = `<script>
   import { Accordion } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <Accordion.Root type="single">
   <Accordion.Item value="a">

--- a/apps/docs/src/routes/components/accordion/+page.ts
+++ b/apps/docs/src/routes/components/accordion/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/alert/+page.svelte
+++ b/apps/docs/src/routes/components/alert/+page.svelte
@@ -49,7 +49,7 @@
 
 	const usageCode = `<script>
   import { Alert } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <Alert.Root color="primary">
   <Alert.Title>Heads up</Alert.Title>

--- a/apps/docs/src/routes/components/alert/+page.svelte
+++ b/apps/docs/src/routes/components/alert/+page.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+	import { Alert } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.alert;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'colors', label: 'Colors' },
+		{ id: 'variants', label: 'Variants' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const rootProps: PropRow[] = [
+		{
+			prop: 'color',
+			type: `'default' | 'primary' | 'success' | 'warning' | 'danger'`,
+			default: `'default'`
+		},
+		{
+			prop: 'variant',
+			type: `'subtle' | 'solid' | 'outline'`,
+			default: `'subtle'`
+		},
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root element.' },
+		{ prop: 'children', type: 'Snippet', description: 'Alert content (Title + Description).' }
+	];
+
+	const titleProps: PropRow[] = [
+		{
+			prop: 'as',
+			type: 'string',
+			default: `'p'`,
+			description: 'HTML element to render as.'
+		},
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the title element.' },
+		{ prop: 'children', type: 'Snippet', description: 'Title text.' }
+	];
+
+	const descriptionProps: PropRow[] = [
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the description element.' },
+		{ prop: 'children', type: 'Snippet', description: 'Description text.' }
+	];
+
+	const usageCode = `<script>
+  import { Alert } from 'sve-ui';
+<\/script>
+
+<Alert.Root color="primary">
+  <Alert.Title>Heads up</Alert.Title>
+  <Alert.Description>New components are available in this release.</Alert.Description>
+</Alert.Root>`;
+
+	const colorsCode = `<Alert.Root color="primary" variant="subtle">
+  <Alert.Title>Info</Alert.Title>
+  <Alert.Description>New components are available in this release.</Alert.Description>
+</Alert.Root>
+<Alert.Root color="success" variant="subtle">
+  <Alert.Title>Success</Alert.Title>
+  <Alert.Description>Your data has been saved successfully.</Alert.Description>
+</Alert.Root>
+<Alert.Root color="warning" variant="subtle">
+  <Alert.Title>Warning</Alert.Title>
+  <Alert.Description>Please review your input before submitting.</Alert.Description>
+</Alert.Root>
+<Alert.Root color="danger" variant="subtle">
+  <Alert.Title>Error</Alert.Title>
+  <Alert.Description>Something went wrong. Please try again.</Alert.Description>
+</Alert.Root>`;
+
+	const variantsCode = `<Alert.Root color="primary" variant="subtle">
+  <Alert.Title>Subtle</Alert.Title>
+  <Alert.Description>Soft background, no border.</Alert.Description>
+</Alert.Root>
+<Alert.Root color="primary" variant="outline">
+  <Alert.Title>Outline</Alert.Title>
+  <Alert.Description>Transparent background, colored border.</Alert.Description>
+</Alert.Root>
+<Alert.Root color="primary" variant="solid">
+  <Alert.Title>Solid</Alert.Title>
+  <Alert.Description>Full color background with contrasting text.</Alert.Description>
+</Alert.Root>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Import the <code class="ic">Alert</code> namespace and compose
+			<code class="ic">Alert.Root</code>, <code class="ic">Alert.Title</code>, and
+			<code class="ic">Alert.Description</code>. No setup required.
+		</p>
+		<Preview code={usageCode} align="start">
+			<Alert.Root color="primary">
+				<Alert.Title>Heads up</Alert.Title>
+				<Alert.Description>New components are available in this release.</Alert.Description>
+			</Alert.Root>
+		</Preview>
+	</section>
+
+	<section id="colors" class="sec">
+		<h2 class="sec__h">Colors</h2>
+		<p class="sec__p">Five semantic tones via the <code class="ic">color</code> prop, all driven by <code class="ic">--sve-*</code> tokens.</p>
+		<Preview code={colorsCode} align="start">
+			<Alert.Root color="primary" variant="subtle">
+				<Alert.Title>Info</Alert.Title>
+				<Alert.Description>New components are available in this release.</Alert.Description>
+			</Alert.Root>
+			<Alert.Root color="success" variant="subtle">
+				<Alert.Title>Success</Alert.Title>
+				<Alert.Description>Your data has been saved successfully.</Alert.Description>
+			</Alert.Root>
+			<Alert.Root color="warning" variant="subtle">
+				<Alert.Title>Warning</Alert.Title>
+				<Alert.Description>Please review your input before submitting.</Alert.Description>
+			</Alert.Root>
+			<Alert.Root color="danger" variant="subtle">
+				<Alert.Title>Error</Alert.Title>
+				<Alert.Description>Something went wrong. Please try again.</Alert.Description>
+			</Alert.Root>
+		</Preview>
+	</section>
+
+	<section id="variants" class="sec">
+		<h2 class="sec__h">Variants</h2>
+		<p class="sec__p">Three visual treatments via the <code class="ic">variant</code> prop.</p>
+		<Preview code={variantsCode} align="start">
+			<Alert.Root color="primary" variant="subtle">
+				<Alert.Title>Subtle</Alert.Title>
+				<Alert.Description>Soft background, no border.</Alert.Description>
+			</Alert.Root>
+			<Alert.Root color="primary" variant="outline">
+				<Alert.Title>Outline</Alert.Title>
+				<Alert.Description>Transparent background, colored border.</Alert.Description>
+			</Alert.Root>
+			<Alert.Root color="primary" variant="solid">
+				<Alert.Title>Solid</Alert.Title>
+				<Alert.Description>Full color background with contrasting text.</Alert.Description>
+			</Alert.Root>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			<code class="ic">Alert.Root</code> — plus every native <code class="ic">&lt;div&gt;</code> attribute via prop spreading.
+		</p>
+		<PropsTable rows={rootProps} />
+
+		<p class="sec__p" style="margin-top: 24px;">
+			<code class="ic">Alert.Title</code>
+		</p>
+		<PropsTable rows={titleProps} />
+
+		<p class="sec__p" style="margin-top: 24px;">
+			<code class="ic">Alert.Description</code>
+		</p>
+		<PropsTable rows={descriptionProps} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/alert/+page.ts
+++ b/apps/docs/src/routes/components/alert/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/avatar/+page.svelte
+++ b/apps/docs/src/routes/components/avatar/+page.svelte
@@ -37,7 +37,7 @@
 
 	const usageCode = `<script>
   import { Avatar } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <Avatar.Root>
   <Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="Jane Doe" />

--- a/apps/docs/src/routes/components/avatar/+page.svelte
+++ b/apps/docs/src/routes/components/avatar/+page.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+	import { Avatar } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.avatar;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'sizes', label: 'Sizes' },
+		{ id: 'shapes', label: 'Shapes' },
+		{ id: 'fallback', label: 'Fallback' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const rootProps: PropRow[] = [
+		{ prop: 'size', type: `'sm' | 'md' | 'lg'`, default: `'md'` },
+		{ prop: 'shape', type: `'circle' | 'square'`, default: `'circle'` },
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root.' },
+		{ prop: 'children', type: 'Snippet', description: 'Avatar.Image and/or Avatar.Fallback.' }
+	];
+
+	const imageProps: PropRow[] = [
+		{ prop: 'src', type: 'string', description: 'Image URL.' },
+		{ prop: 'alt', type: 'string', description: 'Required. Describes the image for screen readers.' },
+		{ prop: 'class', type: 'string', description: 'Extra classes.' }
+	];
+
+	const fallbackProps: PropRow[] = [
+		{ prop: 'class', type: 'string', description: 'Extra classes.' },
+		{ prop: 'children', type: 'Snippet', description: 'Fallback content, typically initials.' }
+	];
+
+	const usageCode = `<script>
+  import { Avatar } from 'sve-ui';
+<\/script>
+
+<Avatar.Root>
+  <Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="Jane Doe" />
+  <Avatar.Fallback>JD</Avatar.Fallback>
+</Avatar.Root>`;
+
+	const sizesCode = `<Avatar.Root size="sm">
+  <Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="User" />
+  <Avatar.Fallback>SM</Avatar.Fallback>
+</Avatar.Root>
+<Avatar.Root size="md">
+  <Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="User" />
+  <Avatar.Fallback>MD</Avatar.Fallback>
+</Avatar.Root>
+<Avatar.Root size="lg">
+  <Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="User" />
+  <Avatar.Fallback>LG</Avatar.Fallback>
+</Avatar.Root>`;
+
+	const shapesCode = `<!-- Circle (default) -->
+<Avatar.Root size="lg" shape="circle">
+  <Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="User" />
+  <Avatar.Fallback>CR</Avatar.Fallback>
+</Avatar.Root>
+
+<!-- Square -->
+<Avatar.Root size="lg" shape="square">
+  <Avatar.Fallback>SQ</Avatar.Fallback>
+</Avatar.Root>`;
+
+	const fallbackCode = `<!-- Fallback shows when no image is provided or image fails to load -->
+<Avatar.Root size="md">
+  <Avatar.Fallback>RA</Avatar.Fallback>
+</Avatar.Root>
+
+<!-- With broken image — fallback kicks in automatically -->
+<Avatar.Root size="md">
+  <Avatar.Image src="https://example.invalid/avatar.jpg" alt="User" />
+  <Avatar.Fallback>PF</Avatar.Fallback>
+</Avatar.Root>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Compose <code class="ic">Avatar.Root</code>, <code class="ic">Avatar.Image</code>, and
+			<code class="ic">Avatar.Fallback</code> together. The fallback renders automatically when the
+			image is absent or fails to load.
+		</p>
+		<Preview code={usageCode}>
+			<Avatar.Root>
+				<Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="Jane Doe" />
+				<Avatar.Fallback>JD</Avatar.Fallback>
+			</Avatar.Root>
+		</Preview>
+	</section>
+
+	<section id="sizes" class="sec">
+		<h2 class="sec__h">Sizes</h2>
+		<p class="sec__p">Three sizes via the <code class="ic">size</code> prop on <code class="ic">Avatar.Root</code>.</p>
+		<Preview code={sizesCode}>
+			<Avatar.Root size="sm">
+				<Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="User" />
+				<Avatar.Fallback>SM</Avatar.Fallback>
+			</Avatar.Root>
+			<Avatar.Root size="md">
+				<Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="User" />
+				<Avatar.Fallback>MD</Avatar.Fallback>
+			</Avatar.Root>
+			<Avatar.Root size="lg">
+				<Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="User" />
+				<Avatar.Fallback>LG</Avatar.Fallback>
+			</Avatar.Root>
+		</Preview>
+	</section>
+
+	<section id="shapes" class="sec">
+		<h2 class="sec__h">Shapes</h2>
+		<p class="sec__p">
+			<code class="ic">circle</code> (default) or <code class="ic">square</code> via the
+			<code class="ic">shape</code> prop.
+		</p>
+		<Preview code={shapesCode}>
+			<Avatar.Root size="lg" shape="circle">
+				<Avatar.Image src="https://i.pravatar.cc/150?img=12" alt="User" />
+				<Avatar.Fallback>CR</Avatar.Fallback>
+			</Avatar.Root>
+			<Avatar.Root size="lg" shape="square">
+				<Avatar.Fallback>SQ</Avatar.Fallback>
+			</Avatar.Root>
+		</Preview>
+	</section>
+
+	<section id="fallback" class="sec">
+		<h2 class="sec__h">Fallback</h2>
+		<p class="sec__p">
+			<code class="ic">Avatar.Fallback</code> renders when no image is provided or when the image
+			fails to load. Typically used with initials.
+		</p>
+		<Preview code={fallbackCode}>
+			<Avatar.Root size="md">
+				<Avatar.Fallback>RA</Avatar.Fallback>
+			</Avatar.Root>
+			<Avatar.Root size="md">
+				<Avatar.Image src="https://example.invalid/avatar.jpg" alt="User" />
+				<Avatar.Fallback>PF</Avatar.Fallback>
+			</Avatar.Root>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p"><code class="ic">Avatar.Root</code></p>
+		<PropsTable rows={rootProps} />
+		<p class="sec__p" style="margin-top: 24px;"><code class="ic">Avatar.Image</code></p>
+		<PropsTable rows={imageProps} />
+		<p class="sec__p" style="margin-top: 24px;"><code class="ic">Avatar.Fallback</code></p>
+		<PropsTable rows={fallbackProps} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/avatar/+page.ts
+++ b/apps/docs/src/routes/components/avatar/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/badge/+page.svelte
+++ b/apps/docs/src/routes/components/badge/+page.svelte
@@ -31,7 +31,7 @@
 
 	const usageCode = `<script>
   import { Badge } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <Badge color="primary">New</Badge>`;
 

--- a/apps/docs/src/routes/components/badge/+page.svelte
+++ b/apps/docs/src/routes/components/badge/+page.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+	import { Badge } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.badge;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'variants', label: 'Variants' },
+		{ id: 'colors', label: 'Colors' },
+		{ id: 'sizes', label: 'Sizes' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{ prop: 'variant', type: `'subtle' | 'solid' | 'outline'`, default: `'subtle'` },
+		{
+			prop: 'color',
+			type: `'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'default'`,
+			default: `'default'`
+		},
+		{ prop: 'size', type: `'sm' | 'md' | 'lg'`, default: `'md'` },
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root.' },
+		{ prop: 'children', type: 'Snippet', description: 'Badge label content.' }
+	];
+
+	const usageCode = `<script>
+  import { Badge } from 'sve-ui';
+<\/script>
+
+<Badge color="primary">New</Badge>`;
+
+	const variantsCode = `<Badge color="primary" variant="subtle">Subtle</Badge>
+<Badge color="primary" variant="solid">Solid</Badge>
+<Badge color="primary" variant="outline">Outline</Badge>`;
+
+	const colorsCode = `<Badge color="primary">Primary</Badge>
+<Badge color="secondary">Secondary</Badge>
+<Badge color="success">Success</Badge>
+<Badge color="warning">Warning</Badge>
+<Badge color="danger">Danger</Badge>
+<Badge color="default">Default</Badge>`;
+
+	const sizesCode = `<Badge color="primary" size="sm">Small</Badge>
+<Badge color="primary" size="md">Medium</Badge>
+<Badge color="primary" size="lg">Large</Badge>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Import and drop in. No setup required — styles ship with the package.
+		</p>
+		<Preview code={usageCode}>
+			<Badge color="primary">New</Badge>
+		</Preview>
+	</section>
+
+	<section id="variants" class="sec">
+		<h2 class="sec__h">Variants</h2>
+		<p class="sec__p">
+			Three visual styles via the <code class="ic">variant</code> prop: <code class="ic">subtle</code>
+			(default), <code class="ic">solid</code>, and <code class="ic">outline</code>.
+		</p>
+		<Preview code={variantsCode}>
+			<Badge color="primary" variant="subtle">Subtle</Badge>
+			<Badge color="primary" variant="solid">Solid</Badge>
+			<Badge color="primary" variant="outline">Outline</Badge>
+		</Preview>
+	</section>
+
+	<section id="colors" class="sec">
+		<h2 class="sec__h">Colors</h2>
+		<p class="sec__p">Semantic tones, all driven by <code class="ic">--sve-*</code> tokens.</p>
+		<Preview code={colorsCode}>
+			<Badge color="primary">Primary</Badge>
+			<Badge color="secondary">Secondary</Badge>
+			<Badge color="success">Success</Badge>
+			<Badge color="warning">Warning</Badge>
+			<Badge color="danger">Danger</Badge>
+			<Badge color="default">Default</Badge>
+		</Preview>
+	</section>
+
+	<section id="sizes" class="sec">
+		<h2 class="sec__h">Sizes</h2>
+		<p class="sec__p">Three sizes from the <code class="ic">size</code> prop.</p>
+		<Preview code={sizesCode}>
+			<Badge color="primary" size="sm">Small</Badge>
+			<Badge color="primary" size="md">Medium</Badge>
+			<Badge color="primary" size="lg">Large</Badge>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Plus every native <code class="ic">&lt;span&gt;</code> attribute via prop spreading.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/badge/+page.ts
+++ b/apps/docs/src/routes/components/badge/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/button/+page.svelte
+++ b/apps/docs/src/routes/components/button/+page.svelte
@@ -34,7 +34,7 @@
 
 	const usageCode = `<script>
   import { Button } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <Button color="primary">Ship it</Button>`;
 

--- a/apps/docs/src/routes/components/button/+page.svelte
+++ b/apps/docs/src/routes/components/button/+page.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	import { Button } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.button;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'variants', label: 'Variants' },
+		{ id: 'colors', label: 'Colors' },
+		{ id: 'sizes', label: 'Sizes' },
+		{ id: 'states', label: 'States' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{ prop: 'variant', type: `'solid' | 'outline' | 'ghost' | 'flat'`, default: `'solid'` },
+		{
+			prop: 'color',
+			type: `'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'default'`,
+			default: `'default'`
+		},
+		{ prop: 'size', type: `'sm' | 'md' | 'lg'`, default: `'md'` },
+		{ prop: 'disabled', type: 'boolean', default: 'false' },
+		{ prop: 'onclick', type: '(e: MouseEvent) => void', description: 'Standard click handler.' },
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root.' },
+		{ prop: 'children', type: 'Snippet', description: 'Button label / content.' }
+	];
+
+	const usageCode = `<script>
+  import { Button } from 'sve-ui';
+<\/script>
+
+<Button color="primary">Ship it</Button>`;
+
+	const variantsCode = `<Button variant="solid" color="primary">Solid</Button>
+<Button variant="outline" color="primary">Outline</Button>
+<Button variant="ghost" color="primary">Ghost</Button>
+<Button variant="flat" color="primary">Flat</Button>`;
+
+	const colorsCode = `<Button color="primary">Primary</Button>
+<Button color="success">Success</Button>
+<Button color="warning">Warning</Button>
+<Button color="danger">Danger</Button>
+<Button color="default">Default</Button>`;
+
+	const sizesCode = `<Button size="sm">Small</Button>
+<Button size="md">Medium</Button>
+<Button size="lg">Large</Button>`;
+
+	const statesCode = `<Button color="primary">Default</Button>
+<Button color="primary" disabled>Disabled</Button>
+<Button color="primary">
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" stroke-width="2.4" stroke-linecap="round"
+    stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
+  With icon
+</Button>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Import the component and use it. No setup, no config — it ships fully styled.
+		</p>
+		<Preview code={usageCode}>
+			<Button color="primary">Ship it</Button>
+		</Preview>
+	</section>
+
+	<section id="variants" class="sec">
+		<h2 class="sec__h">Variants</h2>
+		<p class="sec__p">Four visual treatments via the <code class="ic">variant</code> prop.</p>
+		<Preview code={variantsCode}>
+			<Button variant="solid" color="primary">Solid</Button>
+			<Button variant="outline" color="primary">Outline</Button>
+			<Button variant="ghost" color="primary">Ghost</Button>
+			<Button variant="flat" color="primary">Flat</Button>
+		</Preview>
+	</section>
+
+	<section id="colors" class="sec">
+		<h2 class="sec__h">Colors</h2>
+		<p class="sec__p">Semantic tones, all driven by <code class="ic">--sve-*</code> tokens.</p>
+		<Preview code={colorsCode}>
+			<Button color="primary">Primary</Button>
+			<Button color="success">Success</Button>
+			<Button color="warning">Warning</Button>
+			<Button color="danger">Danger</Button>
+			<Button color="default">Default</Button>
+		</Preview>
+	</section>
+
+	<section id="sizes" class="sec">
+		<h2 class="sec__h">Sizes</h2>
+		<p class="sec__p">Three sizes from the <code class="ic">size</code> prop.</p>
+		<Preview code={sizesCode}>
+			<Button color="primary" size="sm">Small</Button>
+			<Button color="primary" size="md">Medium</Button>
+			<Button color="primary" size="lg">Large</Button>
+		</Preview>
+	</section>
+
+	<section id="states" class="sec">
+		<h2 class="sec__h">States</h2>
+		<p class="sec__p">Disabled is fully styled and non-interactive. Icons compose inline.</p>
+		<Preview code={statesCode}>
+			<Button color="primary">Default</Button>
+			<Button color="primary" disabled>Disabled</Button>
+			<Button color="primary">
+				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
+				With icon
+			</Button>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Plus every native <code class="ic">&lt;button&gt;</code> attribute via prop spreading.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/button/+page.ts
+++ b/apps/docs/src/routes/components/button/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/card/+page.svelte
+++ b/apps/docs/src/routes/components/card/+page.svelte
@@ -30,7 +30,7 @@
 
 	const usageCode = `<script>
   import { Card, Heading, Text } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <Card.Root>
   <Card.Header>

--- a/apps/docs/src/routes/components/card/+page.svelte
+++ b/apps/docs/src/routes/components/card/+page.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+	import { Card, Button, Heading, Text } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.card;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'variants', label: 'Variants' },
+		{ id: 'composition', label: 'Composition' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const rootProps: PropRow[] = [
+		{ prop: 'variant', type: `'elevated' | 'outlined' | 'filled'`, default: `'elevated'` },
+		{ prop: 'padding', type: `'2' | '4' | '6' | '8'`, description: 'Shorthand padding applied to the root. Omit to let Header/Content/Footer control spacing.' },
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root.' },
+		{ prop: 'children', type: 'Snippet', description: 'Card sections (Header, Content, Footer).' }
+	];
+
+	const subProps: PropRow[] = [
+		{ prop: 'class', type: 'string', description: 'Extra classes.' },
+		{ prop: 'children', type: 'Snippet', description: 'Section content.' }
+	];
+
+	const usageCode = `<script>
+  import { Card, Heading, Text } from 'sve-ui';
+<\/script>
+
+<Card.Root>
+  <Card.Header>
+    <Heading level={4} size="sm">Card title</Heading>
+  </Card.Header>
+  <Card.Content>
+    <Text size="sm">Card body content goes here.</Text>
+  </Card.Content>
+</Card.Root>`;
+
+	const variantsCode = `<Card.Root variant="elevated">
+  <Card.Content>
+    <Text size="sm">Elevated — drop shadow, no border.</Text>
+  </Card.Content>
+</Card.Root>
+
+<Card.Root variant="outlined">
+  <Card.Content>
+    <Text size="sm">Outlined — visible border, no shadow.</Text>
+  </Card.Content>
+</Card.Root>
+
+<Card.Root variant="filled">
+  <Card.Content>
+    <Text size="sm">Filled — filled background surface.</Text>
+  </Card.Content>
+</Card.Root>`;
+
+	const compositionCode = `<Card.Root variant="elevated">
+  <Card.Header>
+    <Heading level={4} size="sm">Invoice #1042</Heading>
+  </Card.Header>
+  <Card.Content>
+    <Text size="sm">Due on July 15 · $240.00</Text>
+  </Card.Content>
+  <Card.Footer>
+    <Button variant="solid" color="primary" size="sm">Pay now</Button>
+    <Button variant="ghost" color="default" size="sm">Dismiss</Button>
+  </Card.Footer>
+</Card.Root>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Compose <code class="ic">Card.Root</code> with <code class="ic">Card.Header</code>,
+			<code class="ic">Card.Content</code>, and <code class="ic">Card.Footer</code>. Use only the
+			sections you need.
+		</p>
+		<Preview code={usageCode} align="start">
+			<Card.Root>
+				<Card.Header>
+					<Heading level={4} size="sm">Card title</Heading>
+				</Card.Header>
+				<Card.Content>
+					<Text size="sm">Card body content goes here.</Text>
+				</Card.Content>
+			</Card.Root>
+		</Preview>
+	</section>
+
+	<section id="variants" class="sec">
+		<h2 class="sec__h">Variants</h2>
+		<p class="sec__p">
+			Three surface treatments via the <code class="ic">variant</code> prop on
+			<code class="ic">Card.Root</code>.
+		</p>
+		<Preview code={variantsCode} align="start">
+			<div style="display: flex; flex-direction: column; gap: 14px; width: 100%; max-width: 340px;">
+				<Card.Root variant="elevated">
+					<Card.Content>
+						<Text size="sm">Elevated — drop shadow, no border.</Text>
+					</Card.Content>
+				</Card.Root>
+				<Card.Root variant="outlined">
+					<Card.Content>
+						<Text size="sm">Outlined — visible border, no shadow.</Text>
+					</Card.Content>
+				</Card.Root>
+				<Card.Root variant="filled">
+					<Card.Content>
+						<Text size="sm">Filled — filled background surface.</Text>
+					</Card.Content>
+				</Card.Root>
+			</div>
+		</Preview>
+	</section>
+
+	<section id="composition" class="sec">
+		<h2 class="sec__h">Composition</h2>
+		<p class="sec__p">
+			Header gets a bottom border, Footer gets a top border. Mix in any other Sve·UI component.
+		</p>
+		<Preview code={compositionCode} align="start">
+			<Card.Root variant="elevated" style="width: 100%; max-width: 340px;">
+				<Card.Header>
+					<Heading level={4} size="sm">Invoice #1042</Heading>
+				</Card.Header>
+				<Card.Content>
+					<Text size="sm">Due on July 15 · $240.00</Text>
+				</Card.Content>
+				<Card.Footer>
+					<Button variant="solid" color="primary" size="sm">Pay now</Button>
+					<Button variant="ghost" color="default" size="sm">Dismiss</Button>
+				</Card.Footer>
+			</Card.Root>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p"><code class="ic">Card.Root</code></p>
+		<PropsTable rows={rootProps} />
+		<p class="sec__p" style="margin-top: 24px;">
+			<code class="ic">Card.Header</code> · <code class="ic">Card.Content</code> ·
+			<code class="ic">Card.Footer</code>
+		</p>
+		<PropsTable rows={subProps} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/card/+page.ts
+++ b/apps/docs/src/routes/components/card/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/checkbox/+page.svelte
+++ b/apps/docs/src/routes/components/checkbox/+page.svelte
@@ -33,7 +33,7 @@
 	const usageCode = `<script>
   import { Checkbox } from 'sve-ui';
   let checked = $state(true);
-<\/script>
+<\u002fscript>
 
 <label class="flex items-center gap-2">
   <Checkbox.Root bind:checked />

--- a/apps/docs/src/routes/components/checkbox/+page.svelte
+++ b/apps/docs/src/routes/components/checkbox/+page.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+	import { Checkbox } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.checkbox;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'sizes', label: 'Sizes' },
+		{ id: 'states', label: 'States' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{ prop: 'size', type: `'sm' | 'md' | 'lg'`, default: `'md'` },
+		{ prop: 'checked', type: 'boolean', default: 'false', description: 'Bindable checked state.' },
+		{
+			prop: 'indeterminate',
+			type: 'boolean',
+			default: 'false',
+			description: 'Shows the mixed/indeterminate visual.'
+		},
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root.' }
+	];
+
+	let checkboxOn = $state(true);
+
+	const usageCode = `<script>
+  import { Checkbox } from 'sve-ui';
+  let checked = $state(true);
+<\/script>
+
+<label class="flex items-center gap-2">
+  <Checkbox.Root bind:checked />
+  <span>Accept terms</span>
+</label>`;
+
+	const sizesCode = `<label class="flex items-center gap-2">
+  <Checkbox.Root size="sm" />
+  <span>Small</span>
+</label>
+<label class="flex items-center gap-2">
+  <Checkbox.Root size="md" />
+  <span>Medium</span>
+</label>
+<label class="flex items-center gap-2">
+  <Checkbox.Root size="lg" />
+  <span>Large</span>
+</label>`;
+
+	const statesCode = `<label class="flex items-center gap-2">
+  <Checkbox.Root checked />
+  <span>Checked</span>
+</label>
+<label class="flex items-center gap-2">
+  <Checkbox.Root indeterminate />
+  <span>Indeterminate</span>
+</label>
+<label class="flex items-center gap-2">
+  <Checkbox.Root disabled />
+  <span>Disabled</span>
+</label>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Use <code class="ic">Checkbox.Root</code> inside a label element. Bind to
+			<code class="ic">checked</code> for two-way state.
+		</p>
+		<Preview code={usageCode}>
+			<label class="flex items-center gap-2">
+				<Checkbox.Root bind:checked={checkboxOn} />
+				<span>Accept terms</span>
+			</label>
+		</Preview>
+	</section>
+
+	<section id="sizes" class="sec">
+		<h2 class="sec__h">Sizes</h2>
+		<p class="sec__p">Three sizes from the <code class="ic">size</code> prop.</p>
+		<Preview code={sizesCode}>
+			<label class="flex items-center gap-2">
+				<Checkbox.Root size="sm" />
+				<span>Small</span>
+			</label>
+			<label class="flex items-center gap-2">
+				<Checkbox.Root size="md" />
+				<span>Medium</span>
+			</label>
+			<label class="flex items-center gap-2">
+				<Checkbox.Root size="lg" />
+				<span>Large</span>
+			</label>
+		</Preview>
+	</section>
+
+	<section id="states" class="sec">
+		<h2 class="sec__h">States</h2>
+		<p class="sec__p">
+			<code class="ic">indeterminate</code> renders the mixed state. Both
+			<code class="ic">indeterminate</code> and <code class="ic">disabled</code> are fully
+			accessible.
+		</p>
+		<Preview code={statesCode}>
+			<label class="flex items-center gap-2">
+				<Checkbox.Root checked />
+				<span>Checked</span>
+			</label>
+			<label class="flex items-center gap-2">
+				<Checkbox.Root indeterminate />
+				<span>Indeterminate</span>
+			</label>
+			<label class="flex items-center gap-2">
+				<Checkbox.Root disabled />
+				<span>Disabled</span>
+			</label>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Plus all Bits <code class="ic">Checkbox.Root</code> props via prop spreading.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/checkbox/+page.ts
+++ b/apps/docs/src/routes/components/checkbox/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/code/+page.svelte
+++ b/apps/docs/src/routes/components/code/+page.svelte
@@ -25,7 +25,7 @@
 
 	const usageCode = `<script>
   import { Code } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <Code code="const greeting = 'hello world';" />`;
 

--- a/apps/docs/src/routes/components/code/+page.svelte
+++ b/apps/docs/src/routes/components/code/+page.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import { Code } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.code;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'with-label', label: 'With label' },
+		{ id: 'copy-disabled', label: 'Copy disabled' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{ prop: 'code', type: 'string', description: 'The code string to display and copy. SSR-safe — no DOM scraping.' },
+		{ prop: 'label', type: 'string', description: 'Optional header label, e.g. a filename or language tag.' },
+		{ prop: 'copyable', type: 'boolean', default: 'true', description: 'Show the copy-to-clipboard button.' },
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root element.' }
+	];
+
+	const usageCode = `<script>
+  import { Code } from 'sve-ui';
+<\/script>
+
+<Code code="const greeting = 'hello world';" />`;
+
+	const withLabelCode = `<Code
+  label="App.svelte"
+  code={snippet}
+/>`;
+
+	const copyDisabledCode = `<Code
+  code="export const prerender = true;"
+  copyable={false}
+/>`;
+
+	const snippetCode = `import { Button } from 'sve-ui';
+
+<Button color="primary">Ship it</Button>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Import the component and pass a <code class="ic">code</code> string. The copy button is included
+			by default — no setup required.
+		</p>
+		<Preview code={usageCode}>
+			<Code code="const greeting = 'hello world';" />
+		</Preview>
+	</section>
+
+	<section id="with-label" class="sec">
+		<h2 class="sec__h">With label</h2>
+		<p class="sec__p">
+			Pass a <code class="ic">label</code> to show a header bar with a filename or language tag.
+		</p>
+		<Preview code={withLabelCode}>
+			<Code label="App.svelte" code={snippetCode} />
+		</Preview>
+	</section>
+
+	<section id="copy-disabled" class="sec">
+		<h2 class="sec__h">Copy disabled</h2>
+		<p class="sec__p">
+			Set <code class="ic">copyable={false}</code> to render a plain read-only block with no toolbar.
+		</p>
+		<Preview code={copyDisabledCode}>
+			<Code code="export const prerender = true;" copyable={false} />
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Plus every native <code class="ic">&lt;div&gt;</code> attribute via prop spreading.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/code/+page.ts
+++ b/apps/docs/src/routes/components/code/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/combobox/+page.svelte
+++ b/apps/docs/src/routes/components/combobox/+page.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+	import { Combobox } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.combobox;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'filtering', label: 'Filtering' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{
+			prop: 'Combobox.Root · type',
+			type: `'single' | 'multiple'`,
+			description: 'Selection mode.'
+		},
+		{ prop: 'Combobox.Root · value', type: 'string', description: 'Bindable selected value.' },
+		{
+			prop: 'Combobox.Input · placeholder',
+			type: 'string',
+			description: 'Placeholder text for the search field.'
+		},
+		{
+			prop: 'Combobox.Input · oninput',
+			type: '(e: InputEvent) => void',
+			description: 'Handler to update filter query.'
+		},
+		{ prop: 'Combobox.Input · class', type: 'string', description: 'Extra classes on the input.' },
+		{
+			prop: 'Combobox.Item · value',
+			type: 'string',
+			description: 'Required. The value this item represents.'
+		},
+		{
+			prop: 'Combobox.Item · label',
+			type: 'string',
+			description: 'Required. Accessible label text for the item.'
+		},
+		{ prop: 'Combobox.Item · class', type: 'string', description: 'Extra classes on the item.' }
+	];
+
+	let comboValue = $state('');
+	let comboQuery = $state('');
+	const fruits = ['Apple', 'Banana', 'Cherry', 'Mango'];
+	let filteredFruits = $derived(
+		fruits.filter((f) => f.toLowerCase().includes(comboQuery.toLowerCase()))
+	);
+
+	const usageCode = `<script>
+  import { Combobox } from 'sve-ui';
+  let comboValue = $state('');
+  let comboQuery = $state('');
+  const fruits = ['Apple', 'Banana', 'Cherry', 'Mango'];
+  let filteredFruits = $derived(
+    fruits.filter((f) => f.toLowerCase().includes(comboQuery.toLowerCase()))
+  );
+<\/script>
+
+<Combobox.Root type="single" bind:value={comboValue}>
+  <Combobox.Input
+    placeholder="Search fruit…"
+    oninput={(e) => (comboQuery = e.currentTarget.value)}
+  />
+  <Combobox.Content>
+    {#each filteredFruits as fruit (fruit)}
+      <Combobox.Item value={fruit} label={fruit}>{fruit}</Combobox.Item>
+    {/each}
+  </Combobox.Content>
+</Combobox.Root>`;
+
+	const filteringCode = `<!-- Filtering is consumer-driven: derive from comboQuery -->
+<script>
+  let comboQuery = $state('');
+  let filteredFruits = $derived(
+    fruits.filter((f) => f.toLowerCase().includes(comboQuery.toLowerCase()))
+  );
+<\/script>
+
+<Combobox.Input oninput={(e) => (comboQuery = e.currentTarget.value)} />`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Compose <code class="ic">Combobox.Root</code>, <code class="ic">Combobox.Input</code>,
+			<code class="ic">Combobox.Content</code>, and <code class="ic">Combobox.Item</code>. Filtering
+			is consumer-driven — update a derived list from the input's value.
+		</p>
+		<Preview code={usageCode}>
+			<Combobox.Root type="single" bind:value={comboValue}>
+				<Combobox.Input
+					placeholder="Search fruit…"
+					oninput={(e) => (comboQuery = e.currentTarget.value)}
+				/>
+				<Combobox.Content>
+					{#each filteredFruits as fruit (fruit)}
+						<Combobox.Item value={fruit} label={fruit}>{fruit}</Combobox.Item>
+					{/each}
+				</Combobox.Content>
+			</Combobox.Root>
+		</Preview>
+	</section>
+
+	<section id="filtering" class="sec">
+		<h2 class="sec__h">Filtering</h2>
+		<p class="sec__p">
+			The component does not filter internally. Declare a <code class="ic">comboQuery</code> state
+			variable, update it from <code class="ic">Combobox.Input</code>'s
+			<code class="ic">oninput</code> handler, and derive the filtered list with
+			<code class="ic">$derived</code>. This gives you full control over the matching algorithm.
+		</p>
+		<Preview code={filteringCode}>
+			<Combobox.Root type="single" bind:value={comboValue}>
+				<Combobox.Input
+					placeholder="Type to filter…"
+					oninput={(e) => (comboQuery = e.currentTarget.value)}
+				/>
+				<Combobox.Content>
+					{#each filteredFruits as fruit (fruit)}
+						<Combobox.Item value={fruit} label={fruit}>{fruit}</Combobox.Item>
+					{/each}
+				</Combobox.Content>
+			</Combobox.Root>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			All subcomponents forward their corresponding Bits props and native HTML attributes via
+			spreading.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/combobox/+page.svelte
+++ b/apps/docs/src/routes/components/combobox/+page.svelte
@@ -61,7 +61,7 @@
   let filteredFruits = $derived(
     fruits.filter((f) => f.toLowerCase().includes(comboQuery.toLowerCase()))
   );
-<\/script>
+<\u002fscript>
 
 <Combobox.Root type="single" bind:value={comboValue}>
   <Combobox.Input
@@ -81,7 +81,7 @@
   let filteredFruits = $derived(
     fruits.filter((f) => f.toLowerCase().includes(comboQuery.toLowerCase()))
   );
-<\/script>
+<\u002fscript>
 
 <Combobox.Input oninput={(e) => (comboQuery = e.currentTarget.value)} />`;
 </script>

--- a/apps/docs/src/routes/components/combobox/+page.ts
+++ b/apps/docs/src/routes/components/combobox/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/dialog/+page.svelte
+++ b/apps/docs/src/routes/components/dialog/+page.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+	import { Dialog, Button } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.dialog;
+
+	let open = $state(false);
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'anatomy', label: 'Anatomy' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		// Root
+		{ prop: 'Dialog.Root — open', type: 'boolean', default: 'false', description: 'Controlled open state.' },
+		{ prop: 'Dialog.Root — onOpenChange', type: '(open: boolean) => void', description: 'Callback fired when open state changes.' },
+		// Trigger / Close
+		{ prop: 'Dialog.Trigger — child', type: 'Snippet<[{ props: object }]>', description: 'Render prop that spreads trigger props onto a real element.' },
+		{ prop: 'Dialog.Close — child', type: 'Snippet<[{ props: object }]>', description: 'Render prop that spreads close props onto a real element.' },
+		// Content
+		{ prop: 'Dialog.Content — class', type: 'string', description: 'Extra classes merged onto the content panel.' },
+		// Title / Description
+		{ prop: 'Dialog.Title — level', type: '1 | 2 | 3 | 4 | 5 | 6', default: '2', description: 'Heading level for the dialog title.' },
+		{ prop: 'Dialog.Description — class', type: 'string', description: 'Extra classes merged onto the description.' }
+	];
+
+	const usageCode = `<script>
+  import { Dialog, Button } from 'sve-ui';
+
+  let open = $state(false);
+<\/script>
+
+<Dialog.Root bind:open>
+  <Dialog.Trigger>
+    {#snippet child({ props })}
+      <Button color="primary" {...props}>Open Dialog</Button>
+    {/snippet}
+  </Dialog.Trigger>
+
+  <Dialog.Content>
+    <Dialog.Title>Confirm action</Dialog.Title>
+    <Dialog.Description>
+      This action cannot be undone. Are you sure you want to continue?
+    </Dialog.Description>
+    <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:16px;">
+      <Dialog.Close>
+        {#snippet child({ props })}
+          <Button variant="outline" color="default" size="sm" {...props}>Cancel</Button>
+        {/snippet}
+      </Dialog.Close>
+      <Button variant="solid" color="primary" size="sm" onclick={() => (open = false)}>
+        Confirm
+      </Button>
+    </div>
+  </Dialog.Content>
+</Dialog.Root>`;
+
+	const anatomyCode = `<Dialog.Root bind:open>
+  <Dialog.Trigger>
+    {#snippet child({ props })}
+      <!-- any focusable element -->
+    {/snippet}
+  </Dialog.Trigger>
+
+  <!-- Dialog.Content already portals and includes the overlay internally -->
+  <Dialog.Content>
+    <Dialog.Title>…</Dialog.Title>
+    <Dialog.Description>…</Dialog.Description>
+
+    <Dialog.Close>
+      {#snippet child({ props })}
+        <!-- close button -->
+      {/snippet}
+    </Dialog.Close>
+  </Dialog.Content>
+</Dialog.Root>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Use the <code class="ic">child</code> snippet on <code class="ic">Dialog.Trigger</code> and
+			<code class="ic">Dialog.Close</code> to render real, accessible elements. The trigger spreads
+			all required ARIA and event props onto whatever element you pass.
+		</p>
+		<Preview code={usageCode}>
+			<Dialog.Root bind:open>
+				<Dialog.Trigger>
+					{#snippet child({ props })}
+						<Button color="primary" {...props}>Open Dialog</Button>
+					{/snippet}
+				</Dialog.Trigger>
+
+				<Dialog.Content>
+					<Dialog.Title>Confirm action</Dialog.Title>
+					<Dialog.Description>
+						This action cannot be undone. Are you sure you want to continue?
+					</Dialog.Description>
+					<div style="display:flex; gap:8px; justify-content:flex-end; margin-top:16px;">
+						<Dialog.Close>
+							{#snippet child({ props })}
+								<Button variant="outline" color="default" size="sm" {...props}>Cancel</Button>
+							{/snippet}
+						</Dialog.Close>
+						<Button variant="solid" color="primary" size="sm" onclick={() => (open = false)}>
+							Confirm
+						</Button>
+					</div>
+				</Dialog.Content>
+			</Dialog.Root>
+		</Preview>
+	</section>
+
+	<section id="anatomy" class="sec">
+		<h2 class="sec__h">Anatomy</h2>
+		<p class="sec__p">
+			<code class="ic">Dialog.Content</code> already portals to <code class="ic">&lt;body&gt;</code>
+			and renders the overlay behind the panel — you do not need to add
+			<code class="ic">Dialog.Overlay</code> separately. Focus is trapped inside the content while
+			open; pressing <kbd class="ic">Esc</kbd> closes.
+		</p>
+		<Preview code={anatomyCode}>
+			<span style="font-size:13px; color:var(--doc-fg-muted);">
+				See the Usage example above for a runnable demo.
+			</span>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Built on <code class="ic">bits-ui</code> — all underlying Bits UI Dialog props are forwarded
+			transparently.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/dialog/+page.svelte
+++ b/apps/docs/src/routes/components/dialog/+page.svelte
@@ -35,7 +35,7 @@
   import { Dialog, Button } from 'sve-ui';
 
   let open = $state(false);
-<\/script>
+<\u002fscript>
 
 <Dialog.Root bind:open>
   <Dialog.Trigger>

--- a/apps/docs/src/routes/components/dialog/+page.ts
+++ b/apps/docs/src/routes/components/dialog/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/dropdown-menu/+page.svelte
+++ b/apps/docs/src/routes/components/dropdown-menu/+page.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+	import { DropdownMenu, Button } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug['dropdown-menu'];
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'groups', label: 'Groups & Labels' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		// Root
+		{ prop: 'DropdownMenu.Root — open', type: 'boolean', default: 'false', description: 'Controlled open state.' },
+		{ prop: 'DropdownMenu.Root — onOpenChange', type: '(open: boolean) => void', description: 'Callback fired when open state changes.' },
+		// Trigger
+		{ prop: 'DropdownMenu.Trigger — child', type: 'Snippet<[{ props: object }]>', description: 'Render prop that spreads trigger props onto a real element.' },
+		// Content
+		{ prop: 'DropdownMenu.Content — class', type: 'string', description: 'Extra classes merged onto the menu panel.' },
+		{ prop: 'DropdownMenu.Content — sideOffset', type: 'number', default: '4', description: 'Gap in px between trigger and menu.' },
+		{ prop: 'DropdownMenu.Content — align', type: `'start' | 'center' | 'end'`, default: `'start'`, description: 'Horizontal alignment relative to the trigger.' },
+		// Item
+		{ prop: 'DropdownMenu.Item — disabled', type: 'boolean', default: 'false', description: 'Prevents selection and applies muted styling.' },
+		{ prop: 'DropdownMenu.Item — onSelect', type: '() => void', description: 'Callback fired when the item is selected.' },
+		{ prop: 'DropdownMenu.Item — class', type: 'string', description: 'Extra classes merged onto the item.' },
+		// Separator
+		{ prop: 'DropdownMenu.Separator — class', type: 'string', description: 'Extra classes merged onto the separator.' }
+	];
+
+	const usageCode = `<script>
+  import { DropdownMenu, Button } from 'sve-ui';
+<\/script>
+
+<DropdownMenu.Root>
+  <DropdownMenu.Trigger>
+    {#snippet child({ props })}
+      <Button variant="solid" color="default" {...props}>Options ▾</Button>
+    {/snippet}
+  </DropdownMenu.Trigger>
+
+  <DropdownMenu.Content>
+    <DropdownMenu.Item>Profile</DropdownMenu.Item>
+    <DropdownMenu.Item>Settings</DropdownMenu.Item>
+    <DropdownMenu.Separator />
+    <DropdownMenu.Item>Sign out</DropdownMenu.Item>
+  </DropdownMenu.Content>
+</DropdownMenu.Root>`;
+
+	const groupsCode = `<DropdownMenu.Root>
+  <DropdownMenu.Trigger>
+    {#snippet child({ props })}
+      <Button variant="outline" color="default" {...props}>Account ▾</Button>
+    {/snippet}
+  </DropdownMenu.Trigger>
+
+  <DropdownMenu.Content>
+    <DropdownMenu.Group>
+      <DropdownMenu.Label>My Account</DropdownMenu.Label>
+      <DropdownMenu.Item>Profile</DropdownMenu.Item>
+      <DropdownMenu.Item>Billing</DropdownMenu.Item>
+    </DropdownMenu.Group>
+    <DropdownMenu.Separator />
+    <DropdownMenu.Item disabled>Team (unavailable)</DropdownMenu.Item>
+    <DropdownMenu.Separator />
+    <DropdownMenu.Item>Sign out</DropdownMenu.Item>
+  </DropdownMenu.Content>
+</DropdownMenu.Root>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Wrap your trigger in the <code class="ic">child</code> snippet to forward all required ARIA
+			and positioning props. The menu portals to <code class="ic">&lt;body&gt;</code>, is fully
+			keyboard-navigable, and closes on item select or <kbd class="ic">Esc</kbd>.
+		</p>
+		<Preview code={usageCode}>
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger>
+					{#snippet child({ props })}
+						<Button variant="solid" color="default" {...props}>Options ▾</Button>
+					{/snippet}
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content>
+					<DropdownMenu.Item>Profile</DropdownMenu.Item>
+					<DropdownMenu.Item>Settings</DropdownMenu.Item>
+					<DropdownMenu.Separator />
+					<DropdownMenu.Item>Sign out</DropdownMenu.Item>
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+		</Preview>
+	</section>
+
+	<section id="groups" class="sec">
+		<h2 class="sec__h">Groups & Labels</h2>
+		<p class="sec__p">
+			Use <code class="ic">DropdownMenu.Group</code> with <code class="ic">DropdownMenu.Label</code>
+			to section related items. The <code class="ic">disabled</code> prop on an item prevents
+			selection while keeping it visible.
+		</p>
+		<Preview code={groupsCode}>
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger>
+					{#snippet child({ props })}
+						<Button variant="outline" color="default" {...props}>Account ▾</Button>
+					{/snippet}
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content>
+					<DropdownMenu.Group>
+						<DropdownMenu.Label>My Account</DropdownMenu.Label>
+						<DropdownMenu.Item>Profile</DropdownMenu.Item>
+						<DropdownMenu.Item>Billing</DropdownMenu.Item>
+					</DropdownMenu.Group>
+					<DropdownMenu.Separator />
+					<DropdownMenu.Item disabled>Team (unavailable)</DropdownMenu.Item>
+					<DropdownMenu.Separator />
+					<DropdownMenu.Item>Sign out</DropdownMenu.Item>
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Built on <code class="ic">bits-ui</code> — all underlying Bits UI DropdownMenu props are
+			forwarded transparently.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/dropdown-menu/+page.svelte
+++ b/apps/docs/src/routes/components/dropdown-menu/+page.svelte
@@ -35,7 +35,7 @@
 
 	const usageCode = `<script>
   import { DropdownMenu, Button } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <DropdownMenu.Root>
   <DropdownMenu.Trigger>

--- a/apps/docs/src/routes/components/dropdown-menu/+page.ts
+++ b/apps/docs/src/routes/components/dropdown-menu/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/heading/+page.svelte
+++ b/apps/docs/src/routes/components/heading/+page.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+	import { Heading } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.heading;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'levels', label: 'Levels' },
+		{ id: 'sizes', label: 'Sizes' },
+		{ id: 'colors', label: 'Colors' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{ prop: 'level', type: '1 | 2 | 3 | 4 | 5 | 6', default: '2', description: 'HTML heading element rendered (h1–h6).' },
+		{ prop: 'size', type: `'sm' | 'md' | 'lg'`, description: 'Visual size. Decoupled from semantic level.' },
+		{ prop: 'weight', type: `'normal' | 'medium' | 'bold'`, default: `'bold'` },
+		{
+			prop: 'color',
+			type: `'inherit' | 'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'default'`,
+			default: `'inherit'`
+		},
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root.' },
+		{ prop: 'children', type: 'Snippet', description: 'Heading text content.' }
+	];
+
+	const usageCode = `<script>
+  import { Heading } from 'sve-ui';
+<\/script>
+
+<Heading level={1} size="lg">Ship it</Heading>`;
+
+	const levelsCode = `<!-- Semantic level is independent of visual size -->
+<Heading level={1} size="lg">Heading h1</Heading>
+<Heading level={2} size="md">Heading h2</Heading>
+<Heading level={3} size="sm">Heading h3</Heading>
+<Heading level={4}>Heading h4 — no size, inherits</Heading>`;
+
+	const sizesCode = `<Heading level={2} size="lg">Large display heading</Heading>
+<Heading level={2} size="md">Medium section heading</Heading>
+<Heading level={2} size="sm">Small label heading</Heading>`;
+
+	const colorsCode = `<Heading level={3} size="md" color="primary">Primary</Heading>
+<Heading level={3} size="md" color="success">Success</Heading>
+<Heading level={3} size="md" color="warning">Warning</Heading>
+<Heading level={3} size="md" color="danger">Danger</Heading>
+<Heading level={3} size="md" color="secondary">Secondary</Heading>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			A single <code class="ic">Heading</code> component renders any <code class="ic">h1</code>–<code
+				class="ic">h6</code
+			> element. Visual size is decoupled from the semantic level.
+		</p>
+		<Preview code={usageCode}>
+			<Heading level={1} size="lg">Ship it</Heading>
+		</Preview>
+	</section>
+
+	<section id="levels" class="sec">
+		<h2 class="sec__h">Levels</h2>
+		<p class="sec__p">
+			The <code class="ic">level</code> prop controls the rendered HTML element for correct document
+			structure. Size is set separately.
+		</p>
+		<Preview code={levelsCode} align="start">
+			<div style="display: flex; flex-direction: column; gap: 8px; width: 100%;">
+				<Heading level={1} size="lg">Heading h1</Heading>
+				<Heading level={2} size="md">Heading h2</Heading>
+				<Heading level={3} size="sm">Heading h3</Heading>
+				<Heading level={4}>Heading h4 — no size, inherits</Heading>
+			</div>
+		</Preview>
+	</section>
+
+	<section id="sizes" class="sec">
+		<h2 class="sec__h">Sizes</h2>
+		<p class="sec__p">
+			Three visual sizes via the <code class="ic">size</code> prop, all driven by
+			<code class="ic">--sve-font-size-*</code> tokens.
+		</p>
+		<Preview code={sizesCode} align="start">
+			<div style="display: flex; flex-direction: column; gap: 8px; width: 100%;">
+				<Heading level={2} size="lg">Large display heading</Heading>
+				<Heading level={2} size="md">Medium section heading</Heading>
+				<Heading level={2} size="sm">Small label heading</Heading>
+			</div>
+		</Preview>
+	</section>
+
+	<section id="colors" class="sec">
+		<h2 class="sec__h">Colors</h2>
+		<p class="sec__p">
+			Semantic color tokens via the <code class="ic">color</code> prop. Defaults to
+			<code class="ic">inherit</code> so it picks up the parent's foreground color automatically.
+		</p>
+		<Preview code={colorsCode} align="start">
+			<div style="display: flex; flex-direction: column; gap: 8px; width: 100%;">
+				<Heading level={3} size="md" color="primary">Primary</Heading>
+				<Heading level={3} size="md" color="success">Success</Heading>
+				<Heading level={3} size="md" color="warning">Warning</Heading>
+				<Heading level={3} size="md" color="danger">Danger</Heading>
+				<Heading level={3} size="md" color="secondary">Secondary</Heading>
+			</div>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Plus every native heading attribute via prop spreading.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/heading/+page.svelte
+++ b/apps/docs/src/routes/components/heading/+page.svelte
@@ -32,7 +32,7 @@
 
 	const usageCode = `<script>
   import { Heading } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <Heading level={1} size="lg">Ship it</Heading>`;
 

--- a/apps/docs/src/routes/components/heading/+page.ts
+++ b/apps/docs/src/routes/components/heading/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/input/+page.svelte
+++ b/apps/docs/src/routes/components/input/+page.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+	import { Input } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.input;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'variants', label: 'Variants' },
+		{ id: 'sizes', label: 'Sizes' },
+		{ id: 'states', label: 'States' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{ prop: 'variant', type: `'outline' | 'filled'`, default: `'outline'` },
+		{ prop: 'size', type: `'sm' | 'md' | 'lg'`, default: `'md'` },
+		{ prop: 'invalid', type: 'boolean', default: 'false', description: 'Applies error styling.' },
+		{ prop: 'value', type: 'string', description: 'Bindable value.' },
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root.' }
+	];
+
+	const usageCode = `<script>
+  import { Input } from 'sve-ui';
+<\/script>
+
+<Input placeholder="Enter text…" />`;
+
+	const variantsCode = `<Input variant="outline" placeholder="Outline" />
+<Input variant="filled" placeholder="Filled" />`;
+
+	const sizesCode = `<Input size="sm" placeholder="Small" />
+<Input size="md" placeholder="Medium" />
+<Input size="lg" placeholder="Large" />`;
+
+	const statesCode = `<Input placeholder="Default" />
+<Input placeholder="Invalid" invalid />
+<Input placeholder="Disabled" disabled />`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Import and drop in. Works with all native <code class="ic">&lt;input&gt;</code> attributes via
+			prop spreading.
+		</p>
+		<Preview code={usageCode}>
+			<Input placeholder="Enter text…" />
+		</Preview>
+	</section>
+
+	<section id="variants" class="sec">
+		<h2 class="sec__h">Variants</h2>
+		<p class="sec__p">
+			Two visual styles via the <code class="ic">variant</code> prop:
+			<code class="ic">outline</code> (default) and <code class="ic">filled</code>.
+		</p>
+		<Preview code={variantsCode}>
+			<Input variant="outline" placeholder="Outline" />
+			<Input variant="filled" placeholder="Filled" />
+		</Preview>
+	</section>
+
+	<section id="sizes" class="sec">
+		<h2 class="sec__h">Sizes</h2>
+		<p class="sec__p">Three sizes from the <code class="ic">size</code> prop.</p>
+		<Preview code={sizesCode}>
+			<Input size="sm" placeholder="Small" />
+			<Input size="md" placeholder="Medium" />
+			<Input size="lg" placeholder="Large" />
+		</Preview>
+	</section>
+
+	<section id="states" class="sec">
+		<h2 class="sec__h">States</h2>
+		<p class="sec__p">
+			Use <code class="ic">invalid</code> for error feedback and <code class="ic">disabled</code> to
+			block interaction.
+		</p>
+		<Preview code={statesCode}>
+			<Input placeholder="Default" />
+			<Input placeholder="Invalid" invalid />
+			<Input placeholder="Disabled" disabled />
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Plus every native <code class="ic">&lt;input&gt;</code> attribute via prop spreading.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/input/+page.svelte
+++ b/apps/docs/src/routes/components/input/+page.svelte
@@ -27,7 +27,7 @@
 
 	const usageCode = `<script>
   import { Input } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <Input placeholder="Enter text…" />`;
 

--- a/apps/docs/src/routes/components/input/+page.ts
+++ b/apps/docs/src/routes/components/input/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/popover/+page.svelte
+++ b/apps/docs/src/routes/components/popover/+page.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+	import { Popover, Button } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.popover;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'placement', label: 'Placement' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		// Root
+		{ prop: 'Popover.Root — open', type: 'boolean', default: 'false', description: 'Controlled open state.' },
+		{ prop: 'Popover.Root — onOpenChange', type: '(open: boolean) => void', description: 'Callback fired when open state changes.' },
+		// Trigger
+		{ prop: 'Popover.Trigger — child', type: 'Snippet<[{ props: object }]>', description: 'Render prop that spreads trigger props onto a real element.' },
+		// Content
+		{ prop: 'Popover.Content — class', type: 'string', description: 'Extra classes merged onto the content panel.' },
+		{ prop: 'Popover.Content — side', type: `'top' | 'right' | 'bottom' | 'left'`, default: `'bottom'`, description: 'Preferred side to render the popover.' },
+		{ prop: 'Popover.Content — sideOffset', type: 'number', default: '4', description: 'Gap in px between trigger and content.' },
+		{ prop: 'Popover.Content — align', type: `'start' | 'center' | 'end'`, default: `'start'`, description: 'Alignment of the content relative to the trigger.' },
+		// Close
+		{ prop: 'Popover.Close — child', type: 'Snippet<[{ props: object }]>', description: 'Render prop that spreads close props onto a real element.' }
+	];
+
+	const usageCode = `<script>
+  import { Popover, Button } from 'sve-ui';
+<\/script>
+
+<Popover.Root>
+  <Popover.Trigger>
+    {#snippet child({ props })}
+      <Button variant="outline" color="primary" {...props}>Open Popover</Button>
+    {/snippet}
+  </Popover.Trigger>
+
+  <Popover.Content>
+    <p style="margin:0 0 12px; font-size:14px;">
+      Popovers display rich secondary content anchored to a trigger.
+      They close on outside click or Esc.
+    </p>
+    <Popover.Close>
+      {#snippet child({ props })}
+        <Button variant="ghost" color="default" size="sm" {...props}>Dismiss</Button>
+      {/snippet}
+    </Popover.Close>
+  </Popover.Content>
+</Popover.Root>`;
+
+	const placementCode = `<!-- Preferred side — auto-flips when near viewport edge -->
+<Popover.Root>
+  <Popover.Trigger>
+    {#snippet child({ props })}
+      <Button variant="outline" color="default" size="sm" {...props}>Top</Button>
+    {/snippet}
+  </Popover.Trigger>
+  <Popover.Content side="top">
+    <p style="margin:0; font-size:13px;">Opens above the trigger.</p>
+  </Popover.Content>
+</Popover.Root>
+
+<Popover.Root>
+  <Popover.Trigger>
+    {#snippet child({ props })}
+      <Button variant="outline" color="default" size="sm" {...props}>Right</Button>
+    {/snippet}
+  </Popover.Trigger>
+  <Popover.Content side="right">
+    <p style="margin:0; font-size:13px;">Opens to the right.</p>
+  </Popover.Content>
+</Popover.Root>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Use the <code class="ic">child</code> snippet on <code class="ic">Popover.Trigger</code> to
+			render any element as the anchor. The content portals to <code class="ic">&lt;body&gt;</code>
+			and closes on outside click or <kbd class="ic">Esc</kbd>. Use
+			<code class="ic">Popover.Close</code> for an explicit dismiss action inside the panel.
+		</p>
+		<Preview code={usageCode}>
+			<Popover.Root>
+				<Popover.Trigger>
+					{#snippet child({ props })}
+						<Button variant="outline" color="primary" {...props}>Open Popover</Button>
+					{/snippet}
+				</Popover.Trigger>
+				<Popover.Content>
+					<p style="margin:0 0 12px; font-size:14px; color:var(--doc-fg-muted);">
+						Popovers display rich secondary content anchored to a trigger. They close on outside
+						click or Esc.
+					</p>
+					<Popover.Close>
+						{#snippet child({ props })}
+							<Button variant="ghost" color="default" size="sm" {...props}>Dismiss</Button>
+						{/snippet}
+					</Popover.Close>
+				</Popover.Content>
+			</Popover.Root>
+		</Preview>
+	</section>
+
+	<section id="placement" class="sec">
+		<h2 class="sec__h">Placement</h2>
+		<p class="sec__p">
+			The <code class="ic">side</code> prop sets the preferred placement. The popover
+			auto-flips when there is not enough space near a viewport edge.
+		</p>
+		<Preview code={placementCode}>
+			<div style="display:flex; gap:12px; flex-wrap:wrap;">
+				<Popover.Root>
+					<Popover.Trigger>
+						{#snippet child({ props })}
+							<Button variant="outline" color="default" size="sm" {...props}>Top</Button>
+						{/snippet}
+					</Popover.Trigger>
+					<Popover.Content side="top">
+						<p style="margin:0; font-size:13px; color:var(--doc-fg-muted);">Opens above the trigger.</p>
+					</Popover.Content>
+				</Popover.Root>
+
+				<Popover.Root>
+					<Popover.Trigger>
+						{#snippet child({ props })}
+							<Button variant="outline" color="default" size="sm" {...props}>Right</Button>
+						{/snippet}
+					</Popover.Trigger>
+					<Popover.Content side="right">
+						<p style="margin:0; font-size:13px; color:var(--doc-fg-muted);">Opens to the right.</p>
+					</Popover.Content>
+				</Popover.Root>
+
+				<Popover.Root>
+					<Popover.Trigger>
+						{#snippet child({ props })}
+							<Button variant="outline" color="default" size="sm" {...props}>Bottom</Button>
+						{/snippet}
+					</Popover.Trigger>
+					<Popover.Content side="bottom">
+						<p style="margin:0; font-size:13px; color:var(--doc-fg-muted);">Opens below (default).</p>
+					</Popover.Content>
+				</Popover.Root>
+
+				<Popover.Root>
+					<Popover.Trigger>
+						{#snippet child({ props })}
+							<Button variant="outline" color="default" size="sm" {...props}>Left</Button>
+						{/snippet}
+					</Popover.Trigger>
+					<Popover.Content side="left">
+						<p style="margin:0; font-size:13px; color:var(--doc-fg-muted);">Opens to the left.</p>
+					</Popover.Content>
+				</Popover.Root>
+			</div>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Built on <code class="ic">bits-ui</code> — all underlying Bits UI Popover props are forwarded
+			transparently.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/popover/+page.svelte
+++ b/apps/docs/src/routes/components/popover/+page.svelte
@@ -32,7 +32,7 @@
 
 	const usageCode = `<script>
   import { Popover, Button } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <Popover.Root>
   <Popover.Trigger>

--- a/apps/docs/src/routes/components/popover/+page.ts
+++ b/apps/docs/src/routes/components/popover/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/radio-group/+page.svelte
+++ b/apps/docs/src/routes/components/radio-group/+page.svelte
@@ -36,7 +36,7 @@
 	const usageCode = `<script>
   import { RadioGroup } from 'sve-ui';
   let radioValue = $state('comfortable');
-<\/script>
+<\u002fscript>
 
 <RadioGroup.Root bind:value={radioValue}>
   {#each ['comfortable', 'compact', 'spacious'] as option (option)}

--- a/apps/docs/src/routes/components/radio-group/+page.svelte
+++ b/apps/docs/src/routes/components/radio-group/+page.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+	import { RadioGroup } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug['radio-group'];
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'orientation', label: 'Orientation' },
+		{ id: 'states', label: 'States' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{
+			prop: 'RadioGroup.Root · value',
+			type: 'string',
+			description: 'Bindable selected value.'
+		},
+		{ prop: 'RadioGroup.Root · class', type: 'string', description: 'Extra classes on the root.' },
+		{
+			prop: 'RadioGroup.Item · value',
+			type: 'string',
+			description: 'Required. The value this item represents.'
+		},
+		{ prop: 'RadioGroup.Item · class', type: 'string', description: 'Extra classes on the item.' }
+	];
+
+	let radioValue = $state('comfortable');
+
+	const usageCode = `<script>
+  import { RadioGroup } from 'sve-ui';
+  let radioValue = $state('comfortable');
+<\/script>
+
+<RadioGroup.Root bind:value={radioValue}>
+  {#each ['comfortable', 'compact', 'spacious'] as option (option)}
+    <label class="flex items-center gap-2">
+      <RadioGroup.Item value={option} />
+      <span>{option}</span>
+    </label>
+  {/each}
+</RadioGroup.Root>`;
+
+	const orientationCode = `<RadioGroup.Root orientation="horizontal">
+  {#each ['left', 'center', 'right'] as align (align)}
+    <label class="flex items-center gap-2">
+      <RadioGroup.Item value={align} />
+      <span>{align}</span>
+    </label>
+  {/each}
+</RadioGroup.Root>`;
+
+	const statesCode = `<RadioGroup.Root value="enabled">
+  <label class="flex items-center gap-2">
+    <RadioGroup.Item value="enabled" />
+    <span>Enabled</span>
+  </label>
+  <label class="flex items-center gap-2">
+    <RadioGroup.Item value="disabled" disabled />
+    <span>Disabled item</span>
+  </label>
+</RadioGroup.Root>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Compose <code class="ic">RadioGroup.Root</code> with <code class="ic">RadioGroup.Item</code>
+			inside label elements. Bind the root's <code class="ic">value</code> for selection state.
+		</p>
+		<Preview code={usageCode}>
+			<RadioGroup.Root bind:value={radioValue}>
+				{#each ['comfortable', 'compact', 'spacious'] as option (option)}
+					<label class="flex items-center gap-2">
+						<RadioGroup.Item value={option} />
+						<span>{option}</span>
+					</label>
+				{/each}
+			</RadioGroup.Root>
+		</Preview>
+	</section>
+
+	<section id="orientation" class="sec">
+		<h2 class="sec__h">Orientation</h2>
+		<p class="sec__p">
+			Pass <code class="ic">orientation="horizontal"</code> to <code class="ic">RadioGroup.Root</code
+			> to lay items in a row.
+		</p>
+		<Preview code={orientationCode}>
+			<RadioGroup.Root orientation="horizontal">
+				{#each ['left', 'center', 'right'] as align (align)}
+					<label class="flex items-center gap-2">
+						<RadioGroup.Item value={align} />
+						<span>{align}</span>
+					</label>
+				{/each}
+			</RadioGroup.Root>
+		</Preview>
+	</section>
+
+	<section id="states" class="sec">
+		<h2 class="sec__h">States</h2>
+		<p class="sec__p">
+			Individual items can be <code class="ic">disabled</code> without disabling the whole group.
+		</p>
+		<Preview code={statesCode}>
+			<RadioGroup.Root value="enabled">
+				<label class="flex items-center gap-2">
+					<RadioGroup.Item value="enabled" />
+					<span>Enabled</span>
+				</label>
+				<label class="flex items-center gap-2">
+					<RadioGroup.Item value="disabled" disabled />
+					<span>Disabled item</span>
+				</label>
+			</RadioGroup.Root>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Both subcomponents also forward all Bits <code class="ic">RadioGroup</code> props via spreading.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/radio-group/+page.ts
+++ b/apps/docs/src/routes/components/radio-group/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/select/+page.svelte
+++ b/apps/docs/src/routes/components/select/+page.svelte
@@ -43,7 +43,7 @@
   import { Select } from 'sve-ui';
   let selectValue = $state('');
   const fruits = ['Apple', 'Banana', 'Cherry', 'Mango'];
-<\/script>
+<\u002fscript>
 
 <Select.Root type="single" bind:value={selectValue}>
   <Select.Trigger>{selectValue || 'Pick a fruit'}</Select.Trigger>

--- a/apps/docs/src/routes/components/select/+page.svelte
+++ b/apps/docs/src/routes/components/select/+page.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+	import { Select } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.select;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'states', label: 'States' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{
+			prop: 'Select.Root · type',
+			type: `'single' | 'multiple'`,
+			description: 'Required. Selection mode.'
+		},
+		{ prop: 'Select.Root · value', type: 'string', description: 'Bindable selected value.' },
+		{ prop: 'Select.Trigger · class', type: 'string', description: 'Extra classes on the trigger.' },
+		{
+			prop: 'Select.Item · value',
+			type: 'string',
+			description: 'Required. The value this item represents.'
+		},
+		{
+			prop: 'Select.Item · label',
+			type: 'string',
+			description: 'Required. Accessible label text for the item.'
+		},
+		{ prop: 'Select.Item · class', type: 'string', description: 'Extra classes on the item.' }
+	];
+
+	let selectValue = $state('');
+	const fruits = ['Apple', 'Banana', 'Cherry', 'Mango'];
+
+	const usageCode = `<script>
+  import { Select } from 'sve-ui';
+  let selectValue = $state('');
+  const fruits = ['Apple', 'Banana', 'Cherry', 'Mango'];
+<\/script>
+
+<Select.Root type="single" bind:value={selectValue}>
+  <Select.Trigger>{selectValue || 'Pick a fruit'}</Select.Trigger>
+  <Select.Content>
+    {#each fruits as fruit (fruit)}
+      <Select.Item value={fruit} label={fruit}>{fruit}</Select.Item>
+    {/each}
+  </Select.Content>
+</Select.Root>`;
+
+	const statesCode = `<Select.Root type="single">
+  <Select.Trigger>Pick a fruit</Select.Trigger>
+  <Select.Content>
+    <Select.Item value="apple" label="Apple">Apple</Select.Item>
+    <Select.Item value="banana" label="Banana" disabled>Banana (disabled)</Select.Item>
+    <Select.Item value="cherry" label="Cherry">Cherry</Select.Item>
+  </Select.Content>
+</Select.Root>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Compose <code class="ic">Select.Root</code>, <code class="ic">Select.Trigger</code>,
+			<code class="ic">Select.Content</code>, and <code class="ic">Select.Item</code>. The content
+			portals to the body, so it escapes overflow clipping.
+		</p>
+		<Preview code={usageCode}>
+			<Select.Root type="single" bind:value={selectValue}>
+				<Select.Trigger>{selectValue || 'Pick a fruit'}</Select.Trigger>
+				<Select.Content>
+					{#each fruits as fruit (fruit)}
+						<Select.Item value={fruit} label={fruit}>{fruit}</Select.Item>
+					{/each}
+				</Select.Content>
+			</Select.Root>
+		</Preview>
+	</section>
+
+	<section id="states" class="sec">
+		<h2 class="sec__h">States</h2>
+		<p class="sec__p">
+			Individual items can be <code class="ic">disabled</code> while the rest remain interactive.
+		</p>
+		<Preview code={statesCode}>
+			<Select.Root type="single">
+				<Select.Trigger>Pick a fruit</Select.Trigger>
+				<Select.Content>
+					<Select.Item value="apple" label="Apple">Apple</Select.Item>
+					<Select.Item value="banana" label="Banana" disabled>Banana (disabled)</Select.Item>
+					<Select.Item value="cherry" label="Cherry">Cherry</Select.Item>
+				</Select.Content>
+			</Select.Root>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			All subcomponents also forward their corresponding Bits props via spreading.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/select/+page.ts
+++ b/apps/docs/src/routes/components/select/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/slider/+page.svelte
+++ b/apps/docs/src/routes/components/slider/+page.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	import { Slider } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.slider;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'range', label: 'Range' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{ prop: 'type', type: `'single' | 'multiple'`, default: `'single'` },
+		{ prop: 'value', type: 'number | number[]', description: 'Current value(s). Not bindable — use onValueChange.' },
+		{
+			prop: 'onValueChange',
+			type: '(value: number & number[]) => void',
+			description: 'Callback fired when the value changes.'
+		},
+		{ prop: 'min', type: 'number', description: 'Minimum value.' },
+		{ prop: 'max', type: 'number', description: 'Maximum value.' },
+		{ prop: 'step', type: 'number', description: 'Step increment.' },
+		{ prop: 'disabled', type: 'boolean', default: 'false' },
+		{ prop: 'orientation', type: `'horizontal' | 'vertical'`, default: `'horizontal'` },
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root.' }
+	];
+
+	let sliderValue = $state(40);
+	let rangeValue = $state([20, 70]);
+
+	const usageCode = `<script>
+  import { Slider } from 'sve-ui';
+  let sliderValue = $state(40);
+<\/script>
+
+<Slider
+  type="single"
+  value={sliderValue}
+  onValueChange={(v) => (sliderValue = v as number)}
+  max={100}
+  step={1}
+/>`;
+
+	const rangeCode = `<script>
+  import { Slider } from 'sve-ui';
+  let rangeValue = $state([20, 70]);
+<\/script>
+
+<Slider
+  type="multiple"
+  value={rangeValue}
+  onValueChange={(v) => (rangeValue = v as number[])}
+  max={100}
+  step={1}
+/>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Slider uses <code class="ic">value</code> + <code class="ic">onValueChange</code> instead of
+			<code class="ic">bind:value</code>. Update your state variable inside the callback.
+		</p>
+		<Preview code={usageCode}>
+			<Slider
+				type="single"
+				value={sliderValue}
+				onValueChange={(v) => (sliderValue = v as number)}
+				max={100}
+				step={1}
+			/>
+		</Preview>
+	</section>
+
+	<section id="range" class="sec">
+		<h2 class="sec__h">Range</h2>
+		<p class="sec__p">
+			Pass <code class="ic">type="multiple"</code> and an array as <code class="ic">value</code> to
+			render a two-handle range slider. The callback receives <code class="ic">number[]</code>.
+		</p>
+		<Preview code={rangeCode}>
+			<Slider
+				type="multiple"
+				value={rangeValue}
+				onValueChange={(v) => (rangeValue = v as number[])}
+				max={100}
+				step={1}
+			/>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			The component also forwards all native slider attributes via prop spreading.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/slider/+page.svelte
+++ b/apps/docs/src/routes/components/slider/+page.svelte
@@ -37,7 +37,7 @@
 	const usageCode = `<script>
   import { Slider } from 'sve-ui';
   let sliderValue = $state(40);
-<\/script>
+<\u002fscript>
 
 <Slider
   type="single"
@@ -50,7 +50,7 @@
 	const rangeCode = `<script>
   import { Slider } from 'sve-ui';
   let rangeValue = $state([20, 70]);
-<\/script>
+<\u002fscript>
 
 <Slider
   type="multiple"

--- a/apps/docs/src/routes/components/slider/+page.ts
+++ b/apps/docs/src/routes/components/slider/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/spinner/+page.svelte
+++ b/apps/docs/src/routes/components/spinner/+page.svelte
@@ -34,7 +34,7 @@
 
 	const usageCode = `<script>
   import { Spinner } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <Spinner color="primary" />`;
 

--- a/apps/docs/src/routes/components/spinner/+page.svelte
+++ b/apps/docs/src/routes/components/spinner/+page.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+	import { Spinner } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.spinner;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'sizes', label: 'Sizes' },
+		{ id: 'colors', label: 'Colors' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{ prop: 'size', type: `'sm' | 'md' | 'lg'`, default: `'md'` },
+		{
+			prop: 'color',
+			type: `'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'default'`,
+			default: `'default'`
+		},
+		{
+			prop: 'label',
+			type: 'string',
+			default: `'Loading'`,
+			description: 'Accessible label exposed as aria-label on the status span.'
+		},
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root element.' }
+	];
+
+	const usageCode = `<script>
+  import { Spinner } from 'sve-ui';
+<\/script>
+
+<Spinner color="primary" />`;
+
+	const sizesCode = `<Spinner size="sm" color="primary" />
+<Spinner size="md" color="primary" />
+<Spinner size="lg" color="primary" />`;
+
+	const colorsCode = `<Spinner size="md" color="primary" />
+<Spinner size="md" color="success" />
+<Spinner size="md" color="warning" />
+<Spinner size="md" color="danger" />
+<Spinner size="md" color="default" />`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Import <code class="ic">Spinner</code> and drop it anywhere you need an indeterminate loading
+			indicator. It ships as a single component — no sub-parts.
+		</p>
+		<Preview code={usageCode}>
+			<Spinner color="primary" />
+		</Preview>
+	</section>
+
+	<section id="sizes" class="sec">
+		<h2 class="sec__h">Sizes</h2>
+		<p class="sec__p">Three sizes from the <code class="ic">size</code> prop: <code class="ic">sm</code> (16 px), <code class="ic">md</code> (24 px), and <code class="ic">lg</code> (40 px).</p>
+		<Preview code={sizesCode}>
+			<Spinner size="sm" color="primary" />
+			<Spinner size="md" color="primary" />
+			<Spinner size="lg" color="primary" />
+		</Preview>
+	</section>
+
+	<section id="colors" class="sec">
+		<h2 class="sec__h">Colors</h2>
+		<p class="sec__p">Semantic tones via the <code class="ic">color</code> prop — all driven by <code class="ic">--sve-*</code> tokens through <code class="ic">currentColor</code>.</p>
+		<Preview code={colorsCode}>
+			<Spinner size="md" color="primary" />
+			<Spinner size="md" color="success" />
+			<Spinner size="md" color="warning" />
+			<Spinner size="md" color="danger" />
+			<Spinner size="md" color="default" />
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Plus every native <code class="ic">&lt;span&gt;</code> attribute via prop spreading.
+			The <code class="ic">role="status"</code> and <code class="ic">aria-label</code> are always
+			applied — override <code class="ic">label</code> to localise the accessible name.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/spinner/+page.ts
+++ b/apps/docs/src/routes/components/spinner/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/switch/+page.svelte
+++ b/apps/docs/src/routes/components/switch/+page.svelte
@@ -27,7 +27,7 @@
 	const usageCode = `<script>
   import { Switch } from 'sve-ui';
   let switchOn = $state(true);
-<\/script>
+<\u002fscript>
 
 <Switch.Root bind:checked={switchOn} />`;
 

--- a/apps/docs/src/routes/components/switch/+page.svelte
+++ b/apps/docs/src/routes/components/switch/+page.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import { Switch } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.switch;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'sizes', label: 'Sizes' },
+		{ id: 'states', label: 'States' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{ prop: 'size', type: `'sm' | 'md' | 'lg'`, default: `'md'` },
+		{ prop: 'checked', type: 'boolean', default: 'false', description: 'Bindable toggle state.' },
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root.' }
+	];
+
+	let switchOn = $state(true);
+
+	const usageCode = `<script>
+  import { Switch } from 'sve-ui';
+  let switchOn = $state(true);
+<\/script>
+
+<Switch.Root bind:checked={switchOn} />`;
+
+	const sizesCode = `<Switch.Root size="sm" />
+<Switch.Root size="md" />
+<Switch.Root size="lg" />`;
+
+	const statesCode = `<Switch.Root checked />
+<Switch.Root />
+<Switch.Root checked disabled />`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Bind <code class="ic">checked</code> for two-way state. The switch is fully keyboard and
+			screen-reader accessible out of the box.
+		</p>
+		<Preview code={usageCode}>
+			<Switch.Root bind:checked={switchOn} />
+		</Preview>
+	</section>
+
+	<section id="sizes" class="sec">
+		<h2 class="sec__h">Sizes</h2>
+		<p class="sec__p">Three sizes from the <code class="ic">size</code> prop.</p>
+		<Preview code={sizesCode}>
+			<Switch.Root size="sm" />
+			<Switch.Root size="md" />
+			<Switch.Root size="lg" />
+		</Preview>
+	</section>
+
+	<section id="states" class="sec">
+		<h2 class="sec__h">States</h2>
+		<p class="sec__p">
+			Checked on, checked off, and disabled. The <code class="ic">disabled</code> prop blocks all
+			interaction while keeping the current visual state.
+		</p>
+		<Preview code={statesCode}>
+			<Switch.Root checked />
+			<Switch.Root />
+			<Switch.Root checked disabled />
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Plus all Bits <code class="ic">Switch.Root</code> props via prop spreading.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/switch/+page.ts
+++ b/apps/docs/src/routes/components/switch/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/tabs/+page.svelte
+++ b/apps/docs/src/routes/components/tabs/+page.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+	import { Tabs } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.tabs;
+
+	let tabValue = $state('account');
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{ prop: 'value', type: 'string', description: 'The active tab value. Use bind:value for two-way binding.' },
+		{ prop: 'onValueChange', type: '(value: string) => void', description: 'Called when the active tab changes.' },
+		{ prop: 'orientation', type: `'horizontal' | 'vertical'`, default: `'horizontal'` },
+		{ prop: 'activationMode', type: `'automatic' | 'manual'`, default: `'automatic'` },
+		{ prop: 'loop', type: 'boolean', default: 'true', description: 'Keyboard focus loops from last trigger back to first.' },
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root.' },
+		{ prop: 'children', type: 'Snippet', description: 'Compose Tabs.List and Tabs.Content inside.' }
+	];
+
+	const usageCode = `<script>
+  import { Tabs } from 'sve-ui';
+
+  let tabValue = $state('account');
+<\/script>
+
+<Tabs.Root bind:value={tabValue}>
+  <Tabs.List>
+    <Tabs.Trigger value="account">Account</Tabs.Trigger>
+    <Tabs.Trigger value="password">Password</Tabs.Trigger>
+    <Tabs.Trigger value="team">Team</Tabs.Trigger>
+  </Tabs.List>
+  <Tabs.Content value="account">Manage your account details.</Tabs.Content>
+  <Tabs.Content value="password">Change your password here.</Tabs.Content>
+  <Tabs.Content value="team">Invite and manage team members.</Tabs.Content>
+</Tabs.Root>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Import the namespace and compose <code class="ic">Tabs.Root</code>,
+			<code class="ic">Tabs.List</code>, <code class="ic">Tabs.Trigger</code>, and
+			<code class="ic">Tabs.Content</code>. Use <code class="ic">bind:value</code> to track the active tab.
+		</p>
+		<Preview code={usageCode} align="start">
+			<div style="width: 100%; max-width: 400px;">
+				<Tabs.Root bind:value={tabValue}>
+					<Tabs.List>
+						<Tabs.Trigger value="account">Account</Tabs.Trigger>
+						<Tabs.Trigger value="password">Password</Tabs.Trigger>
+						<Tabs.Trigger value="team">Team</Tabs.Trigger>
+					</Tabs.List>
+					<Tabs.Content value="account">Manage your account details.</Tabs.Content>
+					<Tabs.Content value="password">Change your password here.</Tabs.Content>
+					<Tabs.Content value="team">Invite and manage team members.</Tabs.Content>
+				</Tabs.Root>
+			</div>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Props for <code class="ic">Tabs.Root</code>. <code class="ic">Tabs.Trigger</code> and
+			<code class="ic">Tabs.Content</code> require a matching <code class="ic">value</code> string.
+			All parts accept <code class="ic">class</code> for custom overrides.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/tabs/+page.svelte
+++ b/apps/docs/src/routes/components/tabs/+page.svelte
@@ -30,7 +30,7 @@
   import { Tabs } from 'sve-ui';
 
   let tabValue = $state('account');
-<\/script>
+<\u002fscript>
 
 <Tabs.Root bind:value={tabValue}>
   <Tabs.List>

--- a/apps/docs/src/routes/components/tabs/+page.ts
+++ b/apps/docs/src/routes/components/tabs/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/text/+page.svelte
+++ b/apps/docs/src/routes/components/text/+page.svelte
@@ -39,7 +39,7 @@
 
 	const usageCode = `<script>
   import { Text } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <Text>Body copy, ready to go.</Text>`;
 

--- a/apps/docs/src/routes/components/text/+page.svelte
+++ b/apps/docs/src/routes/components/text/+page.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+	import { Text } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.text;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'sizes', label: 'Sizes' },
+		{ id: 'tones', label: 'Tones' },
+		{ id: 'as-element', label: 'As element' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		{
+			prop: 'as',
+			type: `'p' | 'span' | 'div' | 'label' | 'strong' | 'em' | 'small' | 'li' | 'code' | 'blockquote' | …`,
+			default: `'p'`,
+			description: 'HTML element to render.'
+		},
+		{ prop: 'size', type: `'sm' | 'md' | 'lg'`, description: 'Text size.' },
+		{ prop: 'weight', type: `'normal' | 'medium' | 'bold'`, description: 'Font weight.' },
+		{
+			prop: 'color',
+			type: `'inherit' | 'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'default'`,
+			default: `'inherit'`
+		},
+		{ prop: 'align', type: `'left' | 'center' | 'right' | 'justify'`, description: 'Text alignment.' },
+		{ prop: 'truncate', type: 'boolean', default: 'false', description: 'Truncate with ellipsis on overflow.' },
+		{ prop: 'class', type: 'string', description: 'Extra classes merged onto the root.' },
+		{ prop: 'children', type: 'Snippet', description: 'Text content.' }
+	];
+
+	const usageCode = `<script>
+  import { Text } from 'sve-ui';
+<\/script>
+
+<Text>Body copy, ready to go.</Text>`;
+
+	const sizesCode = `<Text size="lg">Large — size lg</Text>
+<Text size="md">Medium — size md (token default)</Text>
+<Text size="sm">Small — size sm</Text>`;
+
+	const tonesCode = `<Text color="primary" weight="bold">Primary bold</Text>
+<Text color="success" weight="medium">Success medium</Text>
+<Text color="danger">Danger</Text>
+<Text color="warning">Warning</Text>
+<Text color="secondary">Secondary</Text>`;
+
+	const asCode = `<!-- Render as a label element -->
+<Text as="label" size="sm" weight="medium">Email address</Text>
+
+<!-- Render as inline code -->
+<Text as="code" size="sm" color="default">npm install sve-ui</Text>
+
+<!-- Render as strong with semantic weight -->
+<Text as="strong" weight="bold">Important notice.</Text>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			A polymorphic text primitive. Renders as <code class="ic">&lt;p&gt;</code> by default; swap the
+			element via the <code class="ic">as</code> prop without changing any styling.
+		</p>
+		<Preview code={usageCode}>
+			<Text>Body copy, ready to go.</Text>
+		</Preview>
+	</section>
+
+	<section id="sizes" class="sec">
+		<h2 class="sec__h">Sizes</h2>
+		<p class="sec__p">
+			Three sizes via the <code class="ic">size</code> prop, mapped to
+			<code class="ic">--sve-font-size-*</code> tokens.
+		</p>
+		<Preview code={sizesCode} align="start">
+			<div style="display: flex; flex-direction: column; gap: 6px; width: 100%;">
+				<Text size="lg">Large — size lg</Text>
+				<Text size="md">Medium — size md (token default)</Text>
+				<Text size="sm">Small — size sm</Text>
+			</div>
+		</Preview>
+	</section>
+
+	<section id="tones" class="sec">
+		<h2 class="sec__h">Tones</h2>
+		<p class="sec__p">
+			Semantic color tokens via the <code class="ic">color</code> prop. Combine with
+			<code class="ic">weight</code> for emphasis.
+		</p>
+		<Preview code={tonesCode} align="start">
+			<div style="display: flex; flex-direction: column; gap: 6px; width: 100%;">
+				<Text color="primary" weight="bold">Primary bold</Text>
+				<Text color="success" weight="medium">Success medium</Text>
+				<Text color="danger">Danger</Text>
+				<Text color="warning">Warning</Text>
+				<Text color="secondary">Secondary</Text>
+			</div>
+		</Preview>
+	</section>
+
+	<section id="as-element" class="sec">
+		<h2 class="sec__h">As element</h2>
+		<p class="sec__p">
+			Render as any semantic HTML element via the <code class="ic">as</code> prop. The component
+			carries the right styles regardless of the underlying tag.
+		</p>
+		<Preview code={asCode} align="start">
+			<div style="display: flex; flex-direction: column; gap: 8px; width: 100%;">
+				<Text as="label" size="sm" weight="medium">Email address</Text>
+				<Text as="code" size="sm" color="default">npm install sve-ui</Text>
+				<Text as="strong" weight="bold">Important notice.</Text>
+			</div>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Plus every native HTML attribute for the rendered element via prop spreading.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/text/+page.ts
+++ b/apps/docs/src/routes/components/text/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/components/tooltip/+page.svelte
+++ b/apps/docs/src/routes/components/tooltip/+page.svelte
@@ -32,7 +32,7 @@
 
 	const usageCode = `<script>
   import { Tooltip, Button } from 'sve-ui';
-<\/script>
+<\u002fscript>
 
 <!-- Tooltip.Provider must wrap all tooltips on the page (or the whole app) -->
 <Tooltip.Provider>

--- a/apps/docs/src/routes/components/tooltip/+page.svelte
+++ b/apps/docs/src/routes/components/tooltip/+page.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+	import { Tooltip, Button, Badge } from 'sve-ui';
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import PropsTable from '$lib/docs/PropsTable.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import type { PropRow } from '$lib/docs/PropsTable.svelte';
+	import { componentBySlug } from '$lib/docs/registry';
+
+	const meta = componentBySlug.tooltip;
+
+	const toc: TocEntry[] = [
+		{ id: 'usage', label: 'Usage' },
+		{ id: 'placement', label: 'Placement' },
+		{ id: 'props', label: 'Props' }
+	];
+
+	const props: PropRow[] = [
+		// Provider
+		{ prop: 'Tooltip.Provider — delayDuration', type: 'number', default: '700', description: 'Delay in ms before the tooltip opens on hover.' },
+		{ prop: 'Tooltip.Provider — skipDelayDuration', type: 'number', default: '300', description: 'Delay in ms before a second tooltip opens without the full delay.' },
+		// Root
+		{ prop: 'Tooltip.Root — open', type: 'boolean', description: 'Controlled open state.' },
+		{ prop: 'Tooltip.Root — onOpenChange', type: '(open: boolean) => void', description: 'Callback fired when open state changes.' },
+		// Trigger
+		{ prop: 'Tooltip.Trigger — child', type: 'Snippet<[{ props: object }]>', description: 'Render prop that spreads trigger props onto a real element.' },
+		// Content
+		{ prop: 'Tooltip.Content — side', type: `'top' | 'right' | 'bottom' | 'left'`, default: `'top'`, description: 'Preferred side for the tooltip.' },
+		{ prop: 'Tooltip.Content — sideOffset', type: 'number', default: '4', description: 'Gap in px between trigger and tooltip.' },
+		{ prop: 'Tooltip.Content — class', type: 'string', description: 'Extra classes merged onto the tooltip panel.' }
+	];
+
+	const usageCode = `<script>
+  import { Tooltip, Button } from 'sve-ui';
+<\/script>
+
+<!-- Tooltip.Provider must wrap all tooltips on the page (or the whole app) -->
+<Tooltip.Provider>
+  <Tooltip.Root>
+    <Tooltip.Trigger>
+      {#snippet child({ props })}
+        <Button variant="outline" color="default" size="sm" {...props}>Hover me</Button>
+      {/snippet}
+    </Tooltip.Trigger>
+    <Tooltip.Content>Tooltip hint text</Tooltip.Content>
+  </Tooltip.Root>
+</Tooltip.Provider>`;
+
+	const placementCode = `<Tooltip.Provider>
+  <div style="display:flex; gap:12px; flex-wrap:wrap;">
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        {#snippet child({ props })}
+          <Button variant="outline" color="default" size="sm" {...props}>Top</Button>
+        {/snippet}
+      </Tooltip.Trigger>
+      <Tooltip.Content side="top">Opens above</Tooltip.Content>
+    </Tooltip.Root>
+
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        {#snippet child({ props })}
+          <Button variant="outline" color="default" size="sm" {...props}>Right</Button>
+        {/snippet}
+      </Tooltip.Trigger>
+      <Tooltip.Content side="right">Opens to the right</Tooltip.Content>
+    </Tooltip.Root>
+
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        {#snippet child({ props })}
+          <Button variant="outline" color="default" size="sm" {...props}>Bottom</Button>
+        {/snippet}
+      </Tooltip.Trigger>
+      <Tooltip.Content side="bottom">Opens below</Tooltip.Content>
+    </Tooltip.Root>
+  </div>
+</Tooltip.Provider>`;
+</script>
+
+<DocPage group={meta.group} name={meta.name} description={meta.blurb} {toc}>
+	<section id="usage" class="sec">
+		<h2 class="sec__h">Usage</h2>
+		<p class="sec__p">
+			Wrap all tooltips in a single <code class="ic">Tooltip.Provider</code> — it manages shared
+			delay timing and the "skip delay" behaviour when moving between triggers quickly. The
+			<code class="ic">child</code> snippet on <code class="ic">Tooltip.Trigger</code> renders any
+			focusable element as the anchor.
+		</p>
+		<Preview code={usageCode}>
+			<Tooltip.Provider>
+				<div style="display:flex; gap:12px; flex-wrap:wrap; align-items:center;">
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button variant="outline" color="default" size="sm" {...props}>Hover me</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>Tooltip hint text</Tooltip.Content>
+					</Tooltip.Root>
+
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Badge color="primary" {...props}>Badge with tooltip</Badge>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content>Works on any focusable element</Tooltip.Content>
+					</Tooltip.Root>
+				</div>
+			</Tooltip.Provider>
+		</Preview>
+	</section>
+
+	<section id="placement" class="sec">
+		<h2 class="sec__h">Placement</h2>
+		<p class="sec__p">
+			The <code class="ic">side</code> prop on <code class="ic">Tooltip.Content</code> controls
+			preferred placement. Like all floating elements, it auto-flips near viewport edges.
+		</p>
+		<Preview code={placementCode}>
+			<Tooltip.Provider>
+				<div style="display:flex; gap:12px; flex-wrap:wrap;">
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button variant="outline" color="default" size="sm" {...props}>Top</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content side="top">Opens above</Tooltip.Content>
+					</Tooltip.Root>
+
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button variant="outline" color="default" size="sm" {...props}>Right</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content side="right">Opens to the right</Tooltip.Content>
+					</Tooltip.Root>
+
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button variant="outline" color="default" size="sm" {...props}>Bottom</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content side="bottom">Opens below</Tooltip.Content>
+					</Tooltip.Root>
+
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							{#snippet child({ props })}
+								<Button variant="outline" color="default" size="sm" {...props}>Left</Button>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content side="left">Opens to the left</Tooltip.Content>
+					</Tooltip.Root>
+				</div>
+			</Tooltip.Provider>
+		</Preview>
+	</section>
+
+	<section id="props" class="sec">
+		<h2 class="sec__h">Props</h2>
+		<p class="sec__p">
+			Built on <code class="ic">bits-ui</code> — all underlying Bits UI Tooltip props are forwarded
+			transparently.
+		</p>
+		<PropsTable rows={props} />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+</style>

--- a/apps/docs/src/routes/components/tooltip/+page.ts
+++ b/apps/docs/src/routes/components/tooltip/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;


### PR DESCRIPTION
## What

Reworks the docs `/components` area from one long-scroll page into a Radix/shadcn-style **sidebar-docs layout** — one page per component — driven by a central registry. Docs-only change (no library version bump).

## Quick path to review
1. `apps/docs/src/lib/docs/registry.ts` — single source of truth (groups, slugs, blurbs, `ready`/`status`).
2. `apps/docs/src/routes/components/+layout.svelte` — the sidebar shell (search, grouped nav, active state, thin scrollbar, mobile disclosure).
3. `apps/docs/src/lib/docs/{DocPage,Preview,PropsTable}.svelte` — reusable doc primitives.
4. `apps/docs/src/routes/components/button/+page.svelte` — the page pattern every component follows.

## Details

| Area | Decision |
|------|----------|
| Layout | One route per component (`/components/<slug>`), grouped sidebar, breadcrumb + "On this page" rail |
| Data model | Central registry; not-yet-built components show as dimmed **soon** entries (no 404s) |
| Pages | 22 shipped components, each with real props (read from source) + live demos using the real component APIs |
| Roadmap surfacing | 31 upcoming components shown as **soon**, anchored to the Bits UI catalog; new **Data** and **Layout** groups |
| Framework | Stays on SvelteKit — evaluated and rejected Docusaurus (React; can't live-render Svelte) |

## Out of scope (intentional)
- Building the 31 `soon` components (roadmap).
- A reusable `Sidebar` library component — the docs sidebar is app composition; noted in ROADMAP to build the generic primitive first, then dogfood.
- Landing visual changes (already in good shape).

## Verification
- `pnpm --filter docs check` → 813 files, **0 errors, 0 warnings**
- `pnpm --filter docs build` → all routes prerender green
- Fixed an Avatar fallback demo that broke prerender (local `/does-not-exist.jpg` → external `.invalid` URL)