### PR TITLE
test(a11y): axe coverage across all components (+ Slider thumb fix)

### DIFF
--- a/.changeset/slider-thumb-accessible-name.md
+++ b/.changeset/slider-thumb-accessible-name.md
@@ -1,0 +1,5 @@
+---
+"sve-ui": patch
+---
+
+Slider: add a `thumbLabel` prop so the thumb (`role="slider"`) has an accessible name. Without it, axe reported an `aria-input-field-name` violation. In `multiple` mode each thumb's label is suffixed with its position.

--- a/packages/sve-ui/package.json
+++ b/packages/sve-ui/package.json
@@ -50,7 +50,6 @@
 	},
 	"devDependencies": {
 		"@internationalized/date": "^3.8.1",
-		"jsdom": "^26.0.0",
 		"@repo/eslint-config": "workspace:*",
 		"@repo/typescript-config": "workspace:*",
 		"@sveltejs/kit": "catalog:",
@@ -59,13 +58,15 @@
 		"@testing-library/svelte": "catalog:",
 		"eslint": "catalog:",
 		"eslint-plugin-svelte": "catalog:",
+		"jsdom": "^26.0.0",
 		"publint": "catalog:",
 		"svelte": "catalog:",
 		"svelte-check": "^4.0.0",
 		"typescript": "catalog:",
 		"typescript-eslint": "catalog:",
 		"vite": "catalog:",
-		"vitest": "catalog:"
+		"vitest": "catalog:",
+		"vitest-axe": "^0.1.0"
 	},
 	"scripts": {
 		"build": "vite build && pnpm package",

--- a/packages/sve-ui/src/lib/components/Slider/Slider.svelte
+++ b/packages/sve-ui/src/lib/components/Slider/Slider.svelte
@@ -20,10 +20,20 @@
     step?: number;
     disabled?: boolean;
     orientation?: 'horizontal' | 'vertical';
+    /**
+     * Accessible name for the thumb(s). The `role="slider"` element needs a name;
+     * in `multiple` mode each thumb gets the label suffixed with its position.
+     */
+    thumbLabel?: string;
     class?: string;
   }
 
-  let { type = 'single', class: cls, ...rest }: Props = $props();
+  let { type = 'single', thumbLabel, class: cls, ...rest }: Props = $props();
+
+  function thumbName(index: number): string | undefined {
+    if (!thumbLabel) return undefined;
+    return type === 'multiple' ? `${thumbLabel} ${index + 1}` : thumbLabel;
+  }
 
   const className = $derived(['sve-slider', cls].filter(Boolean).join(' '));
 
@@ -36,7 +46,7 @@
       <Slider.Range class="sve-slider__range" />
     </span>
     {#each thumbItems as thumb (thumb.index)}
-      <Slider.Thumb index={thumb.index} class="sve-slider__thumb" />
+      <Slider.Thumb index={thumb.index} class="sve-slider__thumb" aria-label={thumbName(thumb.index)} />
     {/each}
   {/snippet}
 </Root>

--- a/packages/sve-ui/src/tests/A11yFixture.svelte
+++ b/packages/sve-ui/src/tests/A11yFixture.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+	/**
+	 * Kitchen-sink fixture: every component rendered in its INTENDED accessible
+	 * configuration (labels, names, roles present). Used by a11y.test.ts to assert
+	 * the library ships components that pass axe when used correctly.
+	 *
+	 * Interactive overlays render their trigger only (closed state) — opened
+	 * content is portaled and is an e2e concern.
+	 */
+	import Button from '$lib/components/Button/Button.svelte';
+	import Badge from '$lib/components/Badge/Badge.svelte';
+	import Input from '$lib/components/Input/Input.svelte';
+	import Heading from '$lib/components/Heading/Heading.svelte';
+	import Text from '$lib/components/Text/Text.svelte';
+	import Spinner from '$lib/components/Spinner/Spinner.svelte';
+	import Slider from '$lib/components/Slider/Slider.svelte';
+	import Code from '$lib/components/Code/Code.svelte';
+	import * as Avatar from '$lib/components/Avatar/index.js';
+	import * as Card from '$lib/components/Card/index.js';
+	import * as Alert from '$lib/components/Alert/index.js';
+	import * as Tabs from '$lib/components/Tabs/index.js';
+	import * as Accordion from '$lib/components/Accordion/index.js';
+	import * as Switch from '$lib/components/Switch/index.js';
+	import * as Checkbox from '$lib/components/Checkbox/index.js';
+	import * as RadioGroup from '$lib/components/RadioGroup/index.js';
+	import * as Select from '$lib/components/Select/index.js';
+	import * as Combobox from '$lib/components/Combobox/index.js';
+	import * as Dialog from '$lib/components/Dialog/index.js';
+	import * as DropdownMenu from '$lib/components/DropdownMenu/index.js';
+	import * as Popover from '$lib/components/Popover/index.js';
+	import * as Tooltip from '$lib/components/Tooltip/index.js';
+
+	let switchOn = $state(false);
+	let checkboxOn = $state(false);
+	let radioValue = $state('a');
+	let tabValue = $state('a');
+	let selectValue = $state('');
+	let comboValue = $state('');
+</script>
+
+<!-- Display -->
+<section aria-label="Avatar"><Avatar.Root><Avatar.Image src="" alt="Ada Lovelace" /><Avatar.Fallback>AL</Avatar.Fallback></Avatar.Root></section>
+<section aria-label="Badge"><Badge>New</Badge></section>
+<section aria-label="Card"><Card.Root><Card.Header><Heading level={3}>Card title</Heading></Card.Header><Card.Content><Text>Card body content.</Text></Card.Content></Card.Root></section>
+<section aria-label="Typography"><Heading level={2}>Heading</Heading><Text>Body text.</Text></section>
+
+<!-- Forms -->
+<section aria-label="Button"><Button>Save</Button></section>
+<section aria-label="Input"><label>Email<Input type="email" /></label></section>
+<section aria-label="Switch"><Switch.Root aria-label="Enable notifications" bind:checked={switchOn} /></section>
+<section aria-label="Checkbox"><Checkbox.Root aria-label="Accept terms" bind:checked={checkboxOn} /></section>
+<section aria-label="Radio group">
+	<RadioGroup.Root bind:value={radioValue} aria-label="Density">
+		<RadioGroup.Item value="a" aria-label="Comfortable" />
+		<RadioGroup.Item value="b" aria-label="Compact" />
+	</RadioGroup.Root>
+</section>
+<section aria-label="Slider"><Slider value={40} max={100} thumbLabel="Volume" /></section>
+<section aria-label="Select">
+	<Select.Root type="single" bind:value={selectValue}>
+		<Select.Trigger aria-label="Pick a fruit">{selectValue || 'Pick a fruit'}</Select.Trigger>
+		<Select.Content>
+			<Select.Item value="apple" label="Apple">Apple</Select.Item>
+		</Select.Content>
+	</Select.Root>
+</section>
+<section aria-label="Combobox">
+	<Combobox.Root type="single" bind:value={comboValue}>
+		<Combobox.Input aria-label="Search fruit" />
+		<Combobox.Content>
+			<Combobox.Item value="apple" label="Apple">Apple</Combobox.Item>
+		</Combobox.Content>
+	</Combobox.Root>
+</section>
+
+<!-- Feedback -->
+<section aria-label="Alert"><Alert.Root color="success"><Alert.Title>Saved</Alert.Title><Alert.Description>Your changes are live.</Alert.Description></Alert.Root></section>
+<section aria-label="Spinner"><Spinner label="Loading" /></section>
+
+<!-- Navigation -->
+<section aria-label="Tabs">
+	<Tabs.Root bind:value={tabValue}>
+		<Tabs.List>
+			<Tabs.Trigger value="a">Account</Tabs.Trigger>
+			<Tabs.Trigger value="b">Password</Tabs.Trigger>
+		</Tabs.List>
+		<Tabs.Content value="a">Account panel</Tabs.Content>
+		<Tabs.Content value="b">Password panel</Tabs.Content>
+	</Tabs.Root>
+</section>
+<section aria-label="Accordion">
+	<Accordion.Root type="single">
+		<Accordion.Item value="a">
+			<Accordion.Header><Accordion.Trigger>Section</Accordion.Trigger></Accordion.Header>
+			<Accordion.Content>Panel content.</Accordion.Content>
+		</Accordion.Item>
+	</Accordion.Root>
+</section>
+
+<!-- Overlays (trigger / closed state) -->
+<section aria-label="Dialog"><Dialog.Root><Dialog.Trigger>Open dialog</Dialog.Trigger></Dialog.Root></section>
+<section aria-label="Dropdown menu"><DropdownMenu.Root><DropdownMenu.Trigger>Open menu</DropdownMenu.Trigger></DropdownMenu.Root></section>
+<section aria-label="Popover"><Popover.Root><Popover.Trigger>Show details</Popover.Trigger></Popover.Root></section>
+<section aria-label="Tooltip">
+	<Tooltip.Provider>
+		<Tooltip.Root><Tooltip.Trigger>Hover me</Tooltip.Trigger></Tooltip.Root>
+	</Tooltip.Provider>
+</section>
+
+<!-- Utilities -->
+<section aria-label="Code"><Code code="const answer = 42;" /></section>

--- a/packages/sve-ui/src/tests/a11y.test.ts
+++ b/packages/sve-ui/src/tests/a11y.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { axe } from 'vitest-axe';
+import * as axeMatchers from 'vitest-axe/matchers';
+import type { AxeMatchers } from 'vitest-axe/matchers';
+import A11yFixture from './A11yFixture.svelte';
+
+// vitest-axe 0.1.0 ships its types as `declare global namespace Vi`, which
+// Vitest 4 no longer merges into the `vitest` module's Assertion. Augment the
+// `vitest` module directly so `toHaveNoViolations` is typed, and register the
+// matcher at runtime.
+declare module 'vitest' {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unused-vars
+	interface Assertion<T = any> extends AxeMatchers {}
+	// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+	interface AsymmetricMatchersContaining extends AxeMatchers {}
+}
+
+expect.extend(axeMatchers);
+
+/**
+ * Automated a11y coverage with axe-core over every component, used in its
+ * intended accessible configuration (see A11yFixture.svelte).
+ *
+ * jsdom limitations:
+ * - color-contrast cannot run in jsdom (no layout/computed styles); axe skips
+ *   it automatically. Contrast is verified separately in design review and is
+ *   an e2e/browser-mode concern.
+ * - Page-structure rules (region/landmark/page-has-heading-one) are disabled:
+ *   they assert document-level structure that isolated components do not own.
+ */
+const AXE_OPTIONS = {
+	rules: {
+		// jsdom has no layout/computed styles and no canvas → color-contrast both
+		// cannot run and throws on getContext. Disable it (covered in design review).
+		'color-contrast': { enabled: false },
+		region: { enabled: false },
+		'landmark-one-main': { enabled: false },
+		'page-has-heading-one': { enabled: false }
+	}
+} as const;
+
+describe('accessibility (axe)', () => {
+	it('every component passes axe when used as intended', async () => {
+		const { container } = render(A11yFixture);
+		const results = await axe(container, AXE_OPTIONS);
+		expect(results).toHaveNoViolations();
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(jsdom@26.1.0)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@4.1.9(jsdom@26.1.0)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))
 
   packages/typescript-config: {}
 
@@ -1207,6 +1210,10 @@ packages:
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
 
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1240,6 +1247,10 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -1572,6 +1583,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
@@ -1743,6 +1758,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
@@ -1767,6 +1785,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2002,6 +2024,10 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -2098,6 +2124,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
@@ -2286,6 +2316,11 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+
+  vitest-axe@0.1.0:
+    resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
+    peerDependencies:
+      vitest: '>=0.16.0'
 
   vitest@4.1.9:
     resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
@@ -3340,6 +3375,8 @@ snapshots:
 
   async-sema@3.1.1: {}
 
+  axe-core@4.12.1: {}
+
   axobject-query@4.1.0: {}
 
   balanced-match@4.0.4: {}
@@ -3374,6 +3411,8 @@ snapshots:
       fill-range: 7.1.1
 
   chai@6.2.2: {}
+
+  chalk@5.6.2: {}
 
   chardet@2.1.1: {}
 
@@ -3726,6 +3765,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inline-style-parser@0.2.7: {}
 
   is-extglob@2.1.1: {}
@@ -3874,6 +3915,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.startcase@4.4.0: {}
 
   lru-cache@10.4.3: {}
@@ -3892,6 +3935,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -4084,6 +4129,11 @@ snapshots:
 
   readdirp@5.0.0: {}
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   resolve-from@5.0.0: {}
 
   reusify@1.1.0: {}
@@ -4176,6 +4226,10 @@ snapshots:
       ansi-regex: 5.0.1
 
   strip-bom@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   style-to-object@1.0.14:
     dependencies:
@@ -4350,6 +4404,16 @@ snapshots:
   vitefu@1.1.3(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.16(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+
+  vitest-axe@0.1.0(vitest@4.1.9(jsdom@26.1.0)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))):
+    dependencies:
+      aria-query: 5.3.1
+      axe-core: 4.12.1
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 4.1.9(jsdom@26.1.0)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
   vitest@4.1.9(jsdom@26.1.0)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## What

Adds automated accessibility testing with **axe-core** (`vitest-axe`) over every component, used in its intended accessible configuration. The pass already paid for itself: it surfaced and fixed a real a11y bug in **Slider**.

## Quick path to review
1. `packages/sve-ui/src/lib/components/Slider/Slider.svelte` — the fix: new `thumbLabel` prop → accessible name on the `role="slider"` thumb.
2. `packages/sve-ui/src/tests/A11yFixture.svelte` — every component in accessible usage (labels/names present).
3. `packages/sve-ui/src/tests/a11y.test.ts` — renders the fixture, runs axe, asserts no violations.

## Details

| Decision | Why |
|----------|-----|
| `vitest-axe` (fork of jest-axe) | Vitest-native axe matcher; we already run jsdom + @testing-library/svelte |
| `color-contrast` rule disabled | jsdom has no layout/computed styles or canvas — the rule can't run there. Contrast stays a design-review / browser-mode concern |
| `region` / `landmark-one-main` / `page-has-heading-one` disabled | Document-structure rules; isolated components don't own page landmarks |
| Slider gets `thumbLabel` | The thumb carries `role="slider"` and needs an accessible name; multiple mode suffixes each thumb with its position |
| Vitest 4 type augmentation | vitest-axe 0.1.0 ships `declare global namespace Vi`, which Vitest 4 no longer merges — augment the `vitest` module directly |

## Out of scope
- Color-contrast automation (needs Playwright/browser mode — future).
- Documenting `thumbLabel` on the Slider docs page (lands with / after the docs PR #13).

## Verification
- `pnpm --filter sve-ui test` → 28 files, **188 passed + 7 todo**
- `pnpm --filter sve-ui check` → **0 errors**
- `pnpm --filter sve-ui lint` → **0 errors**
- `pnpm --filter sve-ui build` → svelte-package + `publint: All good!`

Includes a changeset (`patch`) for the Slider a11y fix.