### PR TITLE
feat(skills): add sve-ui-usage agent skill

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -293,12 +293,13 @@ Make Sve·UI a first-class citizen for AI-assisted development, so agents (Claud
 Code, Cursor, etc.) generate correct Sve·UI code instead of guessing. Inspired by
 shadcn/ui, which ships both an MCP server and an AI-readable component registry.
 
-- [ ] **Sve·UI usage Skill** — a packaged skill that teaches an agent how to use
-  the library: the wedge (no Tailwind/config), the import + `theme.css` setup, the
-  component API (variant/color/size props), the namespaced-overlay composition
-  pattern (`Dialog.Root`/`Trigger`/`Content`), and the `--sve-*` theming model.
-  Distribute as a skill consumers can drop into their agent so generated code
-  follows our real API (not hallucinated props).
+- [x] **Sve·UI usage Skill** — packaged at `skills/sve-ui-usage/` (LLM-first
+  `SKILL.md` + `references/components.md` catalog). Covers the wedge (no
+  Tailwind/config), `theme.css` setup, single-vs-namespace imports, the `child`
+  snippet for overlay triggers, the body-class theming gotcha for portaled
+  overlays, and the `--sve-*` model. _Remaining: decide distribution — ship under
+  the npm package `files` so consumers get `node_modules/sve-ui/skills/`, and/or
+  publish an `llms.txt`._
 - [ ] **Sve·UI MCP server** (evaluate) — expose the component catalog, prop schemas,
   variant maps and usage examples over MCP so agents can query the real, current
   API at generation time. Compare against simply shipping a static

--- a/skills/sve-ui-usage/SKILL.md
+++ b/skills/sve-ui-usage/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: sve-ui-usage
+description: "Trigger: using sve-ui, sve-ui components, Svelte 5 UI with sve-ui, theming sve-ui. Use the sve-ui component library correctly: imports, namespaces, theming, a11y."
+license: MIT
+metadata:
+  author: rodriabregu
+  version: "1.0"
+---
+
+## Activation Contract
+
+Load when building or editing a Svelte 5 app that consumes `sve-ui` — importing, composing, theming, or debugging unstyled/broken sve-ui components.
+
+## Hard Rules
+
+- Import the stylesheet ONCE at the app root: `import 'sve-ui/theme.css';`. Without it, components render unstyled. The consumer project needs NO Tailwind and NO config.
+- Single components are default imports; composite components are namespaces composed with dots:
+  - Singles: `import { Button, Input, Badge, Spinner, Text, Heading, Slider, Code } from 'sve-ui'`
+  - Namespaces: `Dialog.*`, `Select.*`, `Combobox.*`, `Card.*`, `Alert.*`, `Tabs.*`, `Accordion.*`, `Avatar.*`, `DropdownMenu.*`, `Popover.*`, `Tooltip.*`, `Switch.*`, `Checkbox.*`, `RadioGroup.*`.
+- Overlays (Dialog/DropdownMenu/Popover/Tooltip/Select/Combobox) portal to `<body>`. Put the theme class (`dark`/`light`) on `<body>` so portaled content gets the right `--sve-*` tokens — not only on an inner wrapper.
+- To use a custom element as an overlay trigger, use the Bits `child` snippet:
+  `<Dialog.Trigger>{#snippet child({ props })}<Button {...props}>Open</Button>{/snippet}</Dialog.Trigger>`
+- Theme by overriding `--sve-*` CSS variables (e.g. `--sve-color-primary`). Do NOT put Tailwind layout/margin utilities on sve-ui components — scoped styles win; wrap in a `<div>` instead.
+- `Slider` is NOT `bind:value`; use `value` + `onValueChange`, and give it an accessible name with `thumbLabel`. `Switch`/`Checkbox` need `aria-label` when unlabelled. `Tooltip` requires a `Tooltip.Provider` ancestor.
+
+## Decision Gates
+
+| Need | Use |
+|------|-----|
+| Action button | `Button` |
+| Modal / confirm | `Dialog.*` |
+| Pick one option | `Select.*` (listbox) or `RadioGroup.*` |
+| Filterable pick | `Combobox.*` |
+| On/off vs boolean | `Switch.*` vs `Checkbox.*` |
+| Theme a subtree | wrap in `ThemeProvider` + override `--sve-*` |
+
+## Execution Steps
+
+1. Install: `pnpm add sve-ui`.
+2. Import `sve-ui/theme.css` once in the root layout.
+3. Optionally wrap the app/area in `ThemeProvider` and set `colorScheme`.
+4. Import and compose components per the single/namespace rules above.
+5. For per-component props and copy-paste snippets, read `references/components.md`.
+
+## Output Contract
+
+Svelte 5 markup that imports `theme.css` once, uses correct single/namespace imports and the `child` snippet for custom triggers, gives interactive controls accessible names, and themes via `--sve-*` (no Tailwind in the consumer project).
+
+## References
+
+- `references/components.md` — full component catalog, import style, and per-component usage snippets.
+- GitHub: https://github.com/rodriabregu/sve-ui — source and live docs site.

--- a/skills/sve-ui-usage/references/components.md
+++ b/skills/sve-ui-usage/references/components.md
@@ -1,0 +1,176 @@
+# sve-ui component reference
+
+Minimal correct usage per component. All examples assume `import 'sve-ui/theme.css';` once at the app root. Theme by overriding `--sve-*` variables.
+
+## Import style
+
+- **Singles (default exports):** `Button`, `Input`, `Badge`, `Spinner`, `Text`, `Heading`, `Slider`, `Code`.
+- **Namespaces (`* as`):** `Dialog`, `Select`, `Combobox`, `Card`, `Alert`, `Tabs`, `Accordion`, `Avatar`, `DropdownMenu`, `Popover`, `Tooltip`, `Switch`, `Checkbox`, `RadioGroup`.
+
+```svelte
+import { Button, Input, Badge, Slider } from 'sve-ui';
+import { Dialog, Select, Tabs } from 'sve-ui';
+```
+
+## Display
+
+```svelte
+<!-- Avatar -->
+<Avatar.Root size="md">
+  <Avatar.Image src={url} alt="Ada Lovelace" />
+  <Avatar.Fallback>AL</Avatar.Fallback>
+</Avatar.Root>
+
+<!-- Badge -->
+<Badge color="success" variant="subtle">Active</Badge>
+
+<!-- Card -->
+<Card.Root>
+  <Card.Header><Heading level={3}>Title</Heading></Card.Header>
+  <Card.Content><Text>Body.</Text></Card.Content>
+  <Card.Footer>…</Card.Footer>
+</Card.Root>
+
+<!-- Heading / Text -->
+<Heading level={2} size="lg" weight="bold">Section</Heading>
+<Text size="sm">Body copy.</Text>
+```
+
+## Forms
+
+```svelte
+<!-- Button: variant solid|outline|ghost|flat; color primary|secondary|success|warning|danger|default; size sm|md|lg -->
+<Button variant="solid" color="primary" size="md">Save</Button>
+
+<!-- Input -->
+<label>Email <Input type="email" placeholder="you@example.com" /></label>
+<Input invalid bind:value={pw} />
+
+<!-- Switch / Checkbox: need aria-label if no visible label -->
+<Switch.Root bind:checked={on} aria-label="Notifications" />
+<Checkbox.Root bind:checked={agree} aria-label="Accept terms" />
+
+<!-- RadioGroup -->
+<RadioGroup.Root bind:value={density} aria-label="Density">
+  <RadioGroup.Item value="comfortable" aria-label="Comfortable" />
+  <RadioGroup.Item value="compact" aria-label="Compact" />
+</RadioGroup.Root>
+
+<!-- Slider: value + onValueChange (NOT bind:value); thumbLabel for a11y -->
+<Slider type="single" value={vol} onValueChange={(v) => (vol = v as number)} max={100} step={1} thumbLabel="Volume" />
+
+<!-- Select -->
+<Select.Root type="single" bind:value={fruit}>
+  <Select.Trigger>{fruit || 'Pick a fruit'}</Select.Trigger>
+  <Select.Content>
+    <Select.Item value="apple" label="Apple">Apple</Select.Item>
+  </Select.Content>
+</Select.Root>
+
+<!-- Combobox: filtering is consumer-driven via oninput -->
+<Combobox.Root type="single" bind:value={picked}>
+  <Combobox.Input aria-label="Search" oninput={(e) => (query = e.currentTarget.value)} />
+  <Combobox.Content>
+    {#each filtered as item (item)}
+      <Combobox.Item value={item} label={item}>{item}</Combobox.Item>
+    {/each}
+  </Combobox.Content>
+</Combobox.Root>
+```
+
+## Feedback
+
+```svelte
+<Alert.Root color="warning" variant="subtle">
+  <Alert.Title>Heads up</Alert.Title>
+  <Alert.Description>Check your settings.</Alert.Description>
+</Alert.Root>
+
+<Spinner size="sm" color="primary" label="Loading" />
+```
+
+## Navigation
+
+```svelte
+<Tabs.Root bind:value={tab}>
+  <Tabs.List>
+    <Tabs.Trigger value="a">Account</Tabs.Trigger>
+    <Tabs.Trigger value="b">Password</Tabs.Trigger>
+  </Tabs.List>
+  <Tabs.Content value="a">…</Tabs.Content>
+  <Tabs.Content value="b">…</Tabs.Content>
+</Tabs.Root>
+
+<Accordion.Root type="single">
+  <Accordion.Item value="a">
+    <Accordion.Header><Accordion.Trigger>Section</Accordion.Trigger></Accordion.Header>
+    <Accordion.Content>…</Accordion.Content>
+  </Accordion.Item>
+</Accordion.Root>
+```
+
+## Overlays
+
+All overlays portal to `<body>`; mirror the theme class onto `<body>`. Wrap custom triggers with the Bits `child` snippet.
+
+```svelte
+<!-- Dialog -->
+<Dialog.Root bind:open>
+  <Dialog.Trigger>
+    {#snippet child({ props })}<Button {...props}>Delete</Button>{/snippet}
+  </Dialog.Trigger>
+  <Dialog.Overlay />
+  <Dialog.Content>
+    <Dialog.Title>Delete?</Dialog.Title>
+    <Dialog.Description>This can't be undone.</Dialog.Description>
+    <Dialog.Close>{#snippet child({ props })}<Button variant="outline" {...props}>Cancel</Button>{/snippet}</Dialog.Close>
+  </Dialog.Content>
+</Dialog.Root>
+
+<!-- DropdownMenu -->
+<DropdownMenu.Root>
+  <DropdownMenu.Trigger>{#snippet child({ props })}<Button {...props}>Options</Button>{/snippet}</DropdownMenu.Trigger>
+  <DropdownMenu.Content>
+    <DropdownMenu.Item>Profile</DropdownMenu.Item>
+    <DropdownMenu.Separator />
+    <DropdownMenu.Item>Sign out</DropdownMenu.Item>
+  </DropdownMenu.Content>
+</DropdownMenu.Root>
+
+<!-- Popover -->
+<Popover.Root>
+  <Popover.Trigger>{#snippet child({ props })}<Button {...props}>Details</Button>{/snippet}</Popover.Trigger>
+  <Popover.Content>…</Popover.Content>
+</Popover.Root>
+
+<!-- Tooltip: requires Tooltip.Provider ancestor -->
+<Tooltip.Provider>
+  <Tooltip.Root>
+    <Tooltip.Trigger>{#snippet child({ props })}<Button {...props}>Hover</Button>{/snippet}</Tooltip.Trigger>
+    <Tooltip.Content><Text size="sm">Hint</Text></Tooltip.Content>
+  </Tooltip.Root>
+</Tooltip.Provider>
+```
+
+## Utilities
+
+```svelte
+<Code code={`const answer = 42;`} label="App.svelte" copyable />
+```
+
+## Theming
+
+```svelte
+<script>
+  import { ThemeProvider } from 'sve-ui';
+</script>
+
+<ThemeProvider colorScheme="dark">
+  <!-- override tokens on any wrapper -->
+  <div style="--sve-color-primary: #8b5cf6;">
+    <Button color="primary">Themed</Button>
+  </div>
+</ThemeProvider>
+```
+
+Do not apply Tailwind layout/margin utilities directly on sve-ui components — scoped styles win. Wrap them in a `<div>` and style the wrapper instead.


### PR DESCRIPTION
## What

Adds an **LLM-first skill** so AI agents (Claude Code, Cursor, etc.) generate correct sve-ui code instead of guessing the API. Built with the `skill-creator` conventions. Closes the §12 "usage Skill" roadmap item.

## Files
- `skills/sve-ui-usage/SKILL.md` — runtime instruction contract (activation, hard rules, decision gates, execution steps, output contract).
- `skills/sve-ui-usage/references/components.md` — full component catalog + per-component copy-paste snippets.

## What the skill encodes (the real gotchas)
- Import `sve-ui/theme.css` once; no Tailwind/config in the consumer project.
- Single (default) vs namespace (`Dialog.*`, `Select.*`, …) imports.
- Overlays portal to `<body>` → mirror the theme class onto `<body>`.
- Custom overlay triggers use the Bits `child` snippet.
- `Slider` uses `value` + `onValueChange` (+ `thumbLabel` for a11y); `Switch`/`Checkbox` need `aria-label`; `Tooltip` needs a `Tooltip.Provider`.
- Theme via `--sve-*`; don't put Tailwind layout utilities on components (scoped styles win).

## Out of scope / follow-ups
- Distribution decision: ship `skills/` under the npm package `files` (so consumers get `node_modules/sve-ui/skills/`) and/or publish an `llms.txt`.
- §12 MCP server evaluation (separate item).

Docs/tooling only — no library code change, no changeset.