### PR TITLE
feat(docs): add /docs guides section (intro, installation, theming, AI & agents)

### DIFF
--- a/apps/docs/src/lib/docs/DocPage.svelte
+++ b/apps/docs/src/lib/docs/DocPage.svelte
@@ -11,10 +11,19 @@
 		name: string;
 		description: string;
 		toc?: TocEntry[];
+		/** Top-level breadcrumb link. Defaults to the Components section. */
+		crumb?: { href: string; label: string };
 		children: Snippet;
 	}
 
-	let { group, name, description, toc = [], children }: Props = $props();
+	let {
+		group,
+		name,
+		description,
+		toc = [],
+		crumb = { href: '/components', label: 'Components' },
+		children
+	}: Props = $props();
 </script>
 
 <svelte:head>
@@ -25,7 +34,7 @@
 <div class="docpage">
 	<article class="docpage__main">
 		<nav class="docpage__crumb" aria-label="Breadcrumb">
-			<a href="/components">Components</a>
+			<a href={crumb.href}>{crumb.label}</a>
 			<span class="docpage__crumb-sep">/</span>
 			<span>{group}</span>
 		</nav>

--- a/apps/docs/src/lib/docs/DocsNav.svelte
+++ b/apps/docs/src/lib/docs/DocsNav.svelte
@@ -1,0 +1,281 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { afterNavigate } from '$app/navigation';
+
+	export interface NavItem {
+		name: string;
+		href: string;
+		ready?: boolean;
+		status?: 'new';
+	}
+	export interface NavGroup {
+		label: string;
+		items: NavItem[];
+	}
+
+	interface Props {
+		groups: NavGroup[];
+		searchLabel?: string;
+		toggleLabel?: string;
+	}
+
+	let { groups, searchLabel = 'Search…', toggleLabel = 'Browse' }: Props = $props();
+
+	let query = $state('');
+	/** Mobile-only: the nav panel is collapsed by default; ignored at >= 900px. */
+	let menuOpen = $state(false);
+
+	let filtered = $derived(
+		groups
+			.map((g) => ({
+				...g,
+				items: g.items.filter((it) =>
+					it.name.toLowerCase().includes(query.trim().toLowerCase())
+				)
+			}))
+			.filter((g) => g.items.length > 0)
+	);
+
+	function isActive(href: string): boolean {
+		return page.url.pathname === href;
+	}
+
+	afterNavigate(() => (menuOpen = false));
+</script>
+
+<aside class="docsnav">
+	<button
+		class="docsnav__toggle"
+		onclick={() => (menuOpen = !menuOpen)}
+		aria-expanded={menuOpen}
+		aria-controls="docsnav-panel"
+	>
+		<span>{toggleLabel}</span>
+		<svg
+			class="docsnav__chevron"
+			class:is-open={menuOpen}
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2.2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg
+		>
+	</button>
+
+	<div id="docsnav-panel" class="docsnav__panel" class:is-open={menuOpen}>
+		<div class="docsnav__search">
+			<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.3-4.3" /></svg>
+			<input type="search" placeholder={searchLabel} bind:value={query} aria-label={searchLabel} />
+		</div>
+
+		<nav class="docsnav__nav">
+			{#each filtered as group (group.label)}
+				<div class="docsnav__group">
+					<span class="docsnav__group-label">{group.label}</span>
+					{#each group.items as item (item.href)}
+						{#if item.ready !== false}
+							<a
+								href={item.href}
+								class="docsnav__link"
+								class:is-active={isActive(item.href)}
+								aria-current={isActive(item.href) ? 'page' : undefined}
+							>
+								{item.name}
+								{#if item.status === 'new'}<span class="docsnav__tag">new</span>{/if}
+							</a>
+						{:else}
+							<span class="docsnav__link is-soon">
+								{item.name}
+								<span class="docsnav__soon">soon</span>
+							</span>
+						{/if}
+					{/each}
+				</div>
+			{:else}
+				<p class="docsnav__empty">No matches for “{query}”.</p>
+			{/each}
+		</nav>
+	</div>
+</aside>
+
+<style>
+	.docsnav {
+		padding: 16px 0;
+	}
+
+	@media (min-width: 900px) {
+		.docsnav {
+			position: sticky;
+			top: 64px;
+			align-self: start;
+			height: calc(100vh - 64px);
+			overflow-y: auto;
+			padding: 28px 10px 40px 0;
+			border-right: 1px solid var(--doc-border);
+			scrollbar-width: thin;
+			scrollbar-color: var(--doc-border-2) transparent;
+		}
+		.docsnav::-webkit-scrollbar {
+			width: 7px;
+		}
+		.docsnav::-webkit-scrollbar-track {
+			background: transparent;
+		}
+		.docsnav::-webkit-scrollbar-thumb {
+			background: var(--doc-border);
+			border-radius: 999px;
+		}
+		.docsnav:hover::-webkit-scrollbar-thumb {
+			background: var(--doc-border-2);
+		}
+	}
+
+	.docsnav__toggle {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		padding: 12px 16px;
+		border: 1px solid var(--doc-border-2);
+		border-radius: 11px;
+		background: var(--doc-surface);
+		color: var(--doc-fg);
+		font-family: var(--sve-font-family-sans);
+		font-size: 14.5px;
+		font-weight: 600;
+		cursor: pointer;
+	}
+	.docsnav__chevron {
+		color: var(--doc-fg-subtle);
+		transition: transform 160ms ease;
+	}
+	.docsnav__chevron.is-open {
+		transform: rotate(180deg);
+	}
+
+	@media (min-width: 900px) {
+		.docsnav__toggle {
+			display: none;
+		}
+	}
+
+	.docsnav__panel {
+		display: none;
+		margin-top: 12px;
+		padding-bottom: 8px;
+	}
+	.docsnav__panel.is-open {
+		display: block;
+	}
+
+	@media (min-width: 900px) {
+		.docsnav__panel {
+			display: block;
+			margin-top: 0;
+		}
+	}
+
+	.docsnav__search {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 9px 12px;
+		border: 1px solid var(--doc-border-2);
+		border-radius: 10px;
+		background: var(--doc-surface);
+		color: var(--doc-fg-subtle);
+		margin-bottom: 22px;
+	}
+	.docsnav__search:focus-within {
+		border-color: var(--doc-fg-subtle);
+	}
+	.docsnav__search input {
+		flex: 1;
+		min-width: 0;
+		border: none;
+		outline: none;
+		background: none;
+		font-family: var(--sve-font-family-sans);
+		font-size: 13.5px;
+		color: var(--doc-fg);
+	}
+	.docsnav__search input::placeholder {
+		color: var(--doc-fg-subtle);
+	}
+
+	.docsnav__nav {
+		display: flex;
+		flex-direction: column;
+		gap: 22px;
+	}
+
+	.docsnav__group {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+	}
+
+	.docsnav__group-label {
+		font-size: 11px;
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--doc-fg-subtle);
+		padding: 0 12px 8px;
+	}
+
+	.docsnav__link {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 7px 12px;
+		border-radius: 8px;
+		font-size: 14px;
+		font-weight: 500;
+		color: var(--doc-fg-muted);
+		text-decoration: none;
+		transition: background-color 120ms ease, color 120ms ease;
+	}
+	.docsnav__link:hover:not(.is-soon) {
+		color: var(--doc-fg);
+		background: var(--doc-surface);
+	}
+	.docsnav__link.is-active {
+		color: var(--doc-primary-text);
+		background: color-mix(in srgb, var(--sve-color-primary) 12%, transparent);
+		font-weight: 600;
+	}
+	.docsnav__link.is-soon {
+		color: var(--doc-fg-subtle);
+		cursor: default;
+		justify-content: space-between;
+	}
+
+	.docsnav__tag,
+	.docsnav__soon {
+		font-size: 9.5px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		padding: 2px 6px;
+		border-radius: 999px;
+	}
+	.docsnav__tag {
+		background: color-mix(in srgb, var(--sve-color-primary) 16%, transparent);
+		color: var(--doc-primary-text);
+	}
+	.docsnav__soon {
+		background: var(--doc-surface-2);
+		color: var(--doc-fg-subtle);
+	}
+
+	.docsnav__empty {
+		font-size: 13.5px;
+		color: var(--doc-fg-subtle);
+		padding: 0 12px;
+	}
+</style>

--- a/apps/docs/src/lib/docs/guides.ts
+++ b/apps/docs/src/lib/docs/guides.ts
@@ -1,0 +1,31 @@
+/**
+ * Guide navigation for the /docs section. Mirrors the registry pattern used for
+ * components, but guides are hand-authored pages (no slug → component mapping).
+ */
+
+export interface GuideNavItem {
+	name: string;
+	href: string;
+}
+
+export interface GuideNavGroup {
+	label: string;
+	items: GuideNavItem[];
+}
+
+export const guideGroups: GuideNavGroup[] = [
+	{
+		label: 'Getting started',
+		items: [
+			{ name: 'Introduction', href: '/docs' },
+			{ name: 'Installation', href: '/docs/installation' }
+		]
+	},
+	{
+		label: 'Guides',
+		items: [
+			{ name: 'Theming', href: '/docs/theming' },
+			{ name: 'AI & Agents', href: '/docs/ai-agents' }
+		]
+	}
+];

--- a/apps/docs/src/routes/+layout.svelte
+++ b/apps/docs/src/routes/+layout.svelte
@@ -60,6 +60,11 @@
 
 				<div class="flex items-center gap-6">
 					<a
+						href="/docs"
+						class="hidden no-underline transition-opacity hover:opacity-70 sm:inline"
+						style="color: var(--doc-fg-muted); font-size: 14.5px; font-weight: 500;">Docs</a
+					>
+					<a
 						href="/components"
 						class="hidden no-underline transition-opacity hover:opacity-70 sm:inline"
 						style="color: var(--doc-fg-muted); font-size: 14.5px; font-weight: 500;">Components</a

--- a/apps/docs/src/routes/docs/+layout.svelte
+++ b/apps/docs/src/routes/docs/+layout.svelte
@@ -1,23 +1,13 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import DocsNav from '$lib/docs/DocsNav.svelte';
-	import { componentGroups } from '$lib/docs/registry';
+	import { guideGroups } from '$lib/docs/guides';
 
 	let { children }: { children: Snippet } = $props();
-
-	const navGroups = componentGroups.map((g) => ({
-		label: g.label,
-		items: g.items.map((it) => ({
-			name: it.name,
-			href: `/components/${it.slug}`,
-			ready: it.ready ?? false,
-			status: it.status === 'new' ? ('new' as const) : undefined
-		}))
-	}));
 </script>
 
 <div class="shell">
-	<DocsNav groups={navGroups} searchLabel="Search components…" toggleLabel="Browse components" />
+	<DocsNav groups={guideGroups} searchLabel="Search docs…" toggleLabel="Browse docs" />
 	<div class="shell__content">
 		{@render children()}
 	</div>

--- a/apps/docs/src/routes/docs/+page.svelte
+++ b/apps/docs/src/routes/docs/+page.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import { Button, Text } from 'sve-ui';
+
+	const crumb = { href: '/docs', label: 'Docs' };
+	const toc: TocEntry[] = [
+		{ id: 'what', label: 'What is sve-ui' },
+		{ id: 'why', label: 'Why sve-ui' },
+		{ id: 'next', label: 'Next steps' }
+	];
+</script>
+
+<DocPage
+	group="Getting started"
+	name="Introduction"
+	description="A library of ready-made, fully styled and accessible Svelte 5 components — no Tailwind and no config in your project."
+	{toc}
+	{crumb}
+>
+	<section id="what" class="sec">
+		<h2 class="sec__h">What is sve-ui</h2>
+		<p class="sec__p">
+			sve-ui is a component library for Svelte 5, built on <a
+				class="lnk"
+				href="https://bits-ui.com"
+				target="_blank"
+				rel="noopener">Bits UI</a
+			> for behavior and accessibility, and styled with scoped CSS and
+			<code class="ic">--sve-*</code> custom properties. You install it, import one stylesheet, and use
+			the components — there is no setup step.
+		</p>
+	</section>
+
+	<section id="why" class="sec">
+		<h2 class="sec__h">Why sve-ui</h2>
+		<ul class="sec__list">
+			<li><strong>No Tailwind, no config</strong> in your project — styles ship with the package.</li>
+			<li><strong>Accessible by default</strong> — focus traps, ARIA and keyboard nav via Bits UI.</li>
+			<li><strong>Themeable</strong> — every color, radius and space is a CSS variable; light & dark included.</li>
+			<li><strong>Svelte 5 + runes</strong>, fully typed, tree-shakeable.</li>
+		</ul>
+	</section>
+
+	<section id="next" class="sec">
+		<h2 class="sec__h">Next steps</h2>
+		<p class="sec__p">Install the package, then browse the components.</p>
+		<div class="sec__cta">
+			<Button color="primary" onclick={() => (window.location.href = '/docs/installation')}>
+				Installation
+			</Button>
+			<Button variant="outline" color="default" onclick={() => (window.location.href = '/components')}>
+				Browse components
+			</Button>
+		</div>
+		<Text size="sm" class="mt-3" style="color: var(--doc-fg-subtle);">
+			Building with an AI agent? See the <a class="lnk" href="/docs/ai-agents">AI &amp; Agents</a> guide.
+		</Text>
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.6;
+		color: var(--doc-fg-muted);
+	}
+	.sec__list {
+		margin: 0;
+		padding-left: 18px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.sec__list strong {
+		color: var(--doc-fg);
+	}
+	.sec__cta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 10px;
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+	.lnk {
+		color: var(--doc-primary-text);
+		text-decoration: none;
+		font-weight: 500;
+	}
+	.lnk:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/apps/docs/src/routes/docs/+page.ts
+++ b/apps/docs/src/routes/docs/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/docs/ai-agents/+page.svelte
+++ b/apps/docs/src/routes/docs/ai-agents/+page.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import { Code, Alert } from 'sve-ui';
+
+	const crumb = { href: '/docs', label: 'Docs' };
+	const REPO = 'https://github.com/rodriabregu/sve-ui';
+	const toc: TocEntry[] = [
+		{ id: 'why', label: 'Why a skill' },
+		{ id: 'install', label: 'Add the skill' },
+		{ id: 'encodes', label: 'What it encodes' },
+		{ id: 'status', label: 'Status' }
+	];
+
+	const pathCode = `skills/sve-ui-usage/
+├── SKILL.md              # runtime instruction contract
+└── references/
+    └── components.md     # full catalog + per-component snippets`;
+
+	const useCode = `# Claude Code: copy the skill into your project (or user) skills dir
+cp -r sve-ui/skills/sve-ui-usage .claude/skills/
+
+# Then just ask your agent to build UI with sve-ui — it will
+# follow the real API instead of guessing props.`;
+</script>
+
+<DocPage
+	group="Guides"
+	name="AI & Agents"
+	description="A packaged skill so AI agents (Claude Code, Cursor, …) generate correct sve-ui code instead of hallucinating props."
+	{toc}
+	{crumb}
+>
+	<section id="why" class="sec">
+		<h2 class="sec__h">Why a skill</h2>
+		<p class="sec__p">
+			LLMs guess component APIs. sve-ui ships an <strong>LLM-first skill</strong> that teaches an agent
+			the real rules: the <code class="ic">theme.css</code> setup, single-vs-namespace imports, the
+			Bits <code class="ic">child</code> snippet for overlay triggers, the body-class theming gotcha, and
+			the <code class="ic">--sve-*</code> model. The result: generated code that compiles and matches the
+			library.
+		</p>
+	</section>
+
+	<section id="install" class="sec">
+		<h2 class="sec__h">Add the skill</h2>
+		<p class="sec__p">The skill lives in the repo:</p>
+		<Code code={pathCode} label="skills/" />
+		<p class="sec__p" style="margin-top: 16px;">
+			Drop it into your agent's skills directory:
+		</p>
+		<Code code={useCode} label="Terminal" />
+	</section>
+
+	<section id="encodes" class="sec">
+		<h2 class="sec__h">What it encodes</h2>
+		<ul class="sec__list">
+			<li>Import <code class="ic">sve-ui/theme.css</code> once; no Tailwind/config in the consumer.</li>
+			<li>Single (default) vs namespace (<code class="ic">Dialog.*</code>, <code class="ic">Select.*</code>) imports.</li>
+			<li>Overlays portal to <code class="ic">&lt;body&gt;</code> → mirror the theme class onto it.</li>
+			<li>Custom overlay triggers use the Bits <code class="ic">child</code> snippet.</li>
+			<li><code class="ic">Slider</code> uses <code class="ic">value</code> + <code class="ic">onValueChange</code> (+ <code class="ic">thumbLabel</code>); controls need accessible names.</li>
+			<li>Theme via <code class="ic">--sve-*</code>; don't put Tailwind layout utilities on components.</li>
+		</ul>
+	</section>
+
+	<section id="status" class="sec">
+		<h2 class="sec__h">Status</h2>
+		<Alert.Root color="default" variant="outline">
+			<Alert.Title>Skill: available · llms.txt &amp; MCP: planned</Alert.Title>
+			<Alert.Description>
+				The skill ships in the repo today. A bundled <code class="ic">llms.txt</code> and an evaluation
+				of an MCP server are on the roadmap (§12).
+			</Alert.Description>
+		</Alert.Root>
+		<p class="sec__p" style="margin-top: 16px;">
+			Source: <a class="lnk" href={REPO} target="_blank" rel="noopener">github.com/rodriabregu/sve-ui</a>.
+		</p>
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.6;
+		color: var(--doc-fg-muted);
+	}
+	.sec__list {
+		margin: 0;
+		padding-left: 18px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		font-size: 14.5px;
+		line-height: 1.55;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+	.lnk {
+		color: var(--doc-primary-text);
+		text-decoration: none;
+		font-weight: 500;
+	}
+	.lnk:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/apps/docs/src/routes/docs/ai-agents/+page.ts
+++ b/apps/docs/src/routes/docs/ai-agents/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/docs/installation/+page.svelte
+++ b/apps/docs/src/routes/docs/installation/+page.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import { Button, Code, Alert } from 'sve-ui';
+
+	const crumb = { href: '/docs', label: 'Docs' };
+	const toc: TocEntry[] = [
+		{ id: 'install', label: 'Install' },
+		{ id: 'stylesheet', label: 'Import the stylesheet' },
+		{ id: 'use', label: 'Use a component' },
+		{ id: 'provider', label: 'ThemeProvider (optional)' }
+	];
+
+	const installCode = `pnpm add sve-ui
+# or: npm install sve-ui
+# or: yarn add sve-ui`;
+
+	const styleCode = `// src/routes/+layout.svelte (or your root)
+import 'sve-ui/theme.css';`;
+
+	const useCode = `<script>
+  import { Button } from 'sve-ui';
+</` + `script>
+
+<Button color="primary">Ship it</Button>`;
+
+	const providerCode = `<script>
+  import { ThemeProvider } from 'sve-ui';
+</` + `script>
+
+<ThemeProvider colorScheme="dark">
+  <!-- your app -->
+</ThemeProvider>`;
+</script>
+
+<DocPage
+	group="Getting started"
+	name="Installation"
+	description="Add the package, import the stylesheet once, and start using components. No Tailwind, no config."
+	{toc}
+	{crumb}
+>
+	<section id="install" class="sec">
+		<h2 class="sec__h">Install</h2>
+		<p class="sec__p">Works with pnpm, npm and yarn.</p>
+		<Code code={installCode} label="Terminal" />
+	</section>
+
+	<section id="stylesheet" class="sec">
+		<h2 class="sec__h">Import the stylesheet</h2>
+		<p class="sec__p">
+			Import <code class="ic">sve-ui/theme.css</code> <strong>once</strong> at your app root. This ships
+			all component styles and the default theme tokens.
+		</p>
+		<Code code={styleCode} label="+layout.svelte" />
+		<div class="mt-4">
+			<Alert.Root color="warning" variant="subtle">
+				<Alert.Title>Without the stylesheet, components render unstyled.</Alert.Title>
+				<Alert.Description>It's the only required setup step — there is no Tailwind or config to add.</Alert.Description>
+			</Alert.Root>
+		</div>
+	</section>
+
+	<section id="use" class="sec">
+		<h2 class="sec__h">Use a component</h2>
+		<p class="sec__p">Import and use. Single components are default imports.</p>
+		<Preview code={useCode}>
+			<Button color="primary">Ship it</Button>
+		</Preview>
+	</section>
+
+	<section id="provider" class="sec">
+		<h2 class="sec__h">ThemeProvider (optional)</h2>
+		<p class="sec__p">
+			Wrap your app (or any subtree) in <code class="ic">ThemeProvider</code> to control light/dark and
+			scope theme overrides. See <a class="lnk" href="/docs/theming">Theming</a>.
+		</p>
+		<Code code={providerCode} label="+layout.svelte" />
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.6;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+	.lnk {
+		color: var(--doc-primary-text);
+		text-decoration: none;
+		font-weight: 500;
+	}
+	.lnk:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/apps/docs/src/routes/docs/installation/+page.ts
+++ b/apps/docs/src/routes/docs/installation/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/apps/docs/src/routes/docs/theming/+page.svelte
+++ b/apps/docs/src/routes/docs/theming/+page.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+	import DocPage from '$lib/docs/DocPage.svelte';
+	import type { TocEntry } from '$lib/docs/DocPage.svelte';
+	import Preview from '$lib/docs/Preview.svelte';
+	import { Button, Badge, Code, Alert } from 'sve-ui';
+
+	const crumb = { href: '/docs', label: 'Docs' };
+	const toc: TocEntry[] = [
+		{ id: 'model', label: 'The token model' },
+		{ id: 'override', label: 'Overriding tokens' },
+		{ id: 'darkmode', label: 'Light & dark' },
+		{ id: 'tokens', label: 'Token reference' }
+	];
+
+	const overrideCode = `:root {
+  --sve-color-primary: #8b5cf6;
+  --sve-color-primary-hover: #7c3aed;
+  --sve-radius-md: 0.5rem;
+}`;
+
+	const scopeCode = `<!-- Scope overrides to any subtree -->
+<div style="--sve-color-primary: #10b981;">
+  <Button color="primary">Emerald</Button>
+</div>`;
+
+	const accentCode = `<div style="--sve-color-primary: #8b5cf6;
+  --sve-color-primary-hover: #7c3aed;
+  --sve-color-primary-foreground: #fff;">
+  <Button color="primary">Themed</Button>
+  <Badge color="primary" variant="subtle">Accent</Badge>
+</div>`;
+
+	const bodyClassCode = `// Overlays portal to <body>. Mirror the theme class onto
+// <body> so portaled content gets the right tokens.
+$effect(() => {
+  document.body.classList.toggle('dark', isDark);
+  document.body.classList.toggle('light', !isDark);
+});`;
+</script>
+
+<DocPage
+	group="Guides"
+	name="Theming"
+	description="Every color, radius and space is a --sve-* CSS variable. Override them anywhere — no rebuild, no config."
+	{toc}
+	{crumb}
+>
+	<section id="model" class="sec">
+		<h2 class="sec__h">The token model</h2>
+		<p class="sec__p">
+			Components read <code class="ic">--sve-*</code> custom properties for every visual value. To theme,
+			you set those variables — globally on <code class="ic">:root</code> or scoped to any element. There
+			is no config file and no rebuild.
+		</p>
+	</section>
+
+	<section id="override" class="sec">
+		<h2 class="sec__h">Overriding tokens</h2>
+		<p class="sec__p">Set tokens globally:</p>
+		<Code code={overrideCode} label="app.css" />
+		<p class="sec__p" style="margin-top: 16px;">…or scope them to a subtree:</p>
+		<Code code={scopeCode} label="App.svelte" />
+		<div class="mt-4">
+			<Preview code={accentCode} align="center">
+				<div style="--sve-color-primary: #8b5cf6; --sve-color-primary-hover: #7c3aed; --sve-color-primary-foreground: #fff; --sve-color-primary-surface: color-mix(in srgb, #8b5cf6 14%, transparent); display: flex; gap: 10px; align-items: center;">
+					<Button color="primary">Themed</Button>
+					<Badge color="primary" variant="subtle">Accent</Badge>
+				</div>
+			</Preview>
+		</div>
+		<p class="sec__p" style="margin-top: 16px;">
+			Try the live accent sandbox on the <a class="lnk" href="/#theming">home page</a>.
+		</p>
+	</section>
+
+	<section id="darkmode" class="sec">
+		<h2 class="sec__h">Light &amp; dark</h2>
+		<p class="sec__p">
+			<code class="ic">ThemeProvider</code> toggles a <code class="ic">light</code>/<code class="ic"
+				>dark</code
+			> class that swaps the token set. One gotcha:
+		</p>
+		<Alert.Root color="warning" variant="subtle">
+			<Alert.Title>Overlays portal to &lt;body&gt;</Alert.Title>
+			<Alert.Description>
+				Dialog, Dropdown, Tooltip, Popover, Select and Combobox render their content at the end of
+				&lt;body&gt; — outside your ThemeProvider wrapper. Mirror the theme class onto &lt;body&gt; so
+				they get the right tokens.
+			</Alert.Description>
+		</Alert.Root>
+		<div class="mt-4">
+			<Code code={bodyClassCode} label="+layout.svelte" />
+		</div>
+	</section>
+
+	<section id="tokens" class="sec">
+		<h2 class="sec__h">Token reference</h2>
+		<p class="sec__p">The most-used token families. Each semantic color has hover / active / foreground / surface / border variants.</p>
+		<div class="tok">
+			<table class="tok__table">
+				<thead><tr><th>Token</th><th>Purpose</th></tr></thead>
+				<tbody>
+					<tr><td><code class="ic">--sve-color-primary</code></td><td>Primary accent (+ secondary, success, warning, danger, default)</td></tr>
+					<tr><td><code class="ic">--sve-color-*-foreground</code></td><td>Text/icon color on that surface</td></tr>
+					<tr><td><code class="ic">--sve-color-*-surface</code></td><td>Subtle background tint (flat/ghost states)</td></tr>
+					<tr><td><code class="ic">--sve-radius-md</code></td><td>Corner radius (sm / md / lg / full)</td></tr>
+					<tr><td><code class="ic">--sve-space-*</code></td><td>Spacing scale</td></tr>
+					<tr><td><code class="ic">--sve-font-family-sans</code></td><td>Base font family (and -mono)</td></tr>
+				</tbody>
+			</table>
+		</div>
+	</section>
+</DocPage>
+
+<style>
+	.sec {
+		margin-bottom: 48px;
+		scroll-margin-top: 84px;
+	}
+	.sec__h {
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		color: var(--doc-fg);
+		margin: 0 0 6px;
+	}
+	.sec__p {
+		margin: 0 0 16px;
+		font-size: 14.5px;
+		line-height: 1.6;
+		color: var(--doc-fg-muted);
+	}
+	.ic {
+		font-family: var(--doc-mono);
+		font-size: 0.85em;
+		padding: 1px 5px;
+		border-radius: 5px;
+		background: var(--doc-surface-2);
+		color: var(--doc-primary-text);
+	}
+	.lnk {
+		color: var(--doc-primary-text);
+		text-decoration: none;
+		font-weight: 500;
+	}
+	.lnk:hover {
+		text-decoration: underline;
+	}
+	.tok {
+		border: 1px solid var(--doc-border);
+		border-radius: 14px;
+		overflow: hidden;
+		background: var(--doc-surface);
+	}
+	.tok__table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 13.5px;
+	}
+	.tok__table th {
+		text-align: left;
+		padding: 12px 18px;
+		font-size: 11px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--doc-fg-subtle);
+		background: var(--doc-surface-2);
+		border-bottom: 1px solid var(--doc-border);
+	}
+	.tok__table td {
+		padding: 13px 18px;
+		vertical-align: top;
+		color: var(--doc-fg-muted);
+		border-bottom: 1px solid var(--doc-border);
+	}
+	.tok__table tbody tr:last-child td {
+		border-bottom: none;
+	}
+</style>

--- a/apps/docs/src/routes/docs/theming/+page.ts
+++ b/apps/docs/src/routes/docs/theming/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;


### PR DESCRIPTION
## What

Adds a general **/docs guides** section alongside `/components`. Until now the site had only a component reference and a marketing landing — no home for installation, theming, or the AI skill. This fills that gap.

## Quick path to review
1. `apps/docs/src/lib/docs/DocsNav.svelte` — shared sidebar (search, grouped nav, active state, mobile disclosure) extracted from the components layout.
2. `apps/docs/src/routes/docs/+layout.svelte` + `lib/docs/guides.ts` — the guides shell + nav data.
3. `apps/docs/src/routes/docs/ai-agents/+page.svelte` — home for the `sve-ui-usage` skill.

## Details

| Change | Why |
|--------|-----|
| Extract `DocsNav` | `/components` and `/docs` now share one sidebar (DRY); was inline-only |
| `DocPage` `crumb` prop | Breadcrumb was hardcoded to "Components"; guides need "Docs" |
| Top nav: add **Docs** | The section needs an entry point |
| Pages: Introduction, Installation, Theming, AI & Agents | Minimal-but-complete getting-started + the skill's home |

Theming page documents the `--sve-*` token model + the portaled-overlay body-class gotcha. AI & Agents documents the skill (added in #15), its contents, and the planned `llms.txt`/MCP.

## Verification
- `pnpm --filter docs check` → 828 files, **0 errors**
- `pnpm --filter docs lint` → **0 errors**
- `pnpm --filter docs build` → all routes prerender green (fixed a readiness-mapping bug where `soon` items briefly became crawlable links)

Docs-only — no library change, no changeset.