### PR TITLE
feat(docs): add /llms.txt for AI agents; defer MCP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -308,11 +308,20 @@ shadcn/ui, which ships both an MCP server and an AI-readable component registry.
   overlays, and the `--sve-*` model. _Remaining: decide distribution — ship under
   the npm package `files` so consumers get `node_modules/sve-ui/skills/`, and/or
   publish an `llms.txt`._
-- [ ] **Sve·UI MCP server** (evaluate) — expose the component catalog, prop schemas,
-  variant maps and usage examples over MCP so agents can query the real, current
-  API at generation time. Compare against simply shipping a static
-  machine-readable registry (`registry.json` / `llms.txt`) — the registry may
-  cover 90% of the value at a fraction of the maintenance cost; decide MCP vs.
-  static registry before building.
+- [x] **`llms.txt`** — served at `/llms.txt`, generated from the component registry
+  + guide nav (`apps/docs/src/routes/llms.txt/+server.ts`, prerendered) so it never
+  drifts. Static, zero-infra, works with any agent. This is the "static registry"
+  that covers ~90% of the MCP value.
+- [x] **Sve·UI MCP server — evaluated, DEFERRED (2026-06-22).** Verdict: not now.
+  Rationale: shadcn's MCP headline value is browse + **install** components from a
+  registry; sve-ui is a styled npm package (D17), NOT a copy-paste registry, so that
+  action doesn't exist for us. The remaining need (feed agents the real API) is
+  covered by the Skill + `llms.txt` at zero hosting/config cost; an MCP adds a hosted
+  service, maintenance, and per-consumer client config for marginal gain. **Revisit
+  when:** we want agent _actions_ a static file can't do (scaffold a themed page,
+  validate usage, generate compositions), or prop schemas auto-generated from types
+  grow large/volatile enough that querying beats a static file.
+- [ ] **Skill distribution** (open) — ship `skills/` under the npm package `files` so
+  consumers get `node_modules/sve-ui/skills/`, and link `llms.txt` from the package.
 - [ ] Auto-generate the registry/skill content from component types + variant
   definitions so it never drifts from the source.

--- a/apps/docs/src/routes/docs/ai-agents/+page.svelte
+++ b/apps/docs/src/routes/docs/ai-agents/+page.svelte
@@ -9,7 +9,8 @@
 		{ id: 'why', label: 'Why a skill' },
 		{ id: 'install', label: 'Add the skill' },
 		{ id: 'encodes', label: 'What it encodes' },
-		{ id: 'status', label: 'Status' }
+		{ id: 'llms', label: 'llms.txt' },
+		{ id: 'status', label: 'Status & MCP' }
 	];
 
 	const pathCode = `skills/sve-ui-usage/
@@ -64,15 +65,32 @@ cp -r sve-ui/skills/sve-ui-usage .claude/skills/
 		</ul>
 	</section>
 
+	<section id="llms" class="sec">
+		<h2 class="sec__h">llms.txt</h2>
+		<p class="sec__p">
+			Any agent (no skill install needed) can read
+			<a class="lnk" href="/llms.txt">sveui.org/llms.txt</a> — a concise, always-current index of
+			the usage rules, docs and full component catalog, generated from the component registry so it
+			never drifts.
+		</p>
+	</section>
+
 	<section id="status" class="sec">
-		<h2 class="sec__h">Status</h2>
-		<Alert.Root color="default" variant="outline">
-			<Alert.Title>Skill: available · llms.txt &amp; MCP: planned</Alert.Title>
+		<h2 class="sec__h">Status &amp; the MCP question</h2>
+		<Alert.Root color="success" variant="subtle">
+			<Alert.Title>Skill &amp; llms.txt: available · MCP: not planned</Alert.Title>
 			<Alert.Description>
-				The skill ships in the repo today. A bundled <code class="ic">llms.txt</code> and an evaluation
-				of an MCP server are on the roadmap (§12).
+				The skill and <code class="ic">llms.txt</code> ship today. An MCP server is intentionally
+				deferred.
 			</Alert.Description>
 		</Alert.Root>
+		<p class="sec__p" style="margin-top: 16px;">
+			An MCP server's headline value (browse + <strong>install</strong> components from a registry)
+			doesn't apply here: sve-ui is a styled npm package, not a copy-paste registry — you
+			<code class="ic">pnpm add sve-ui</code> once. The remaining need (feeding agents the real API) is
+			already covered by the skill and <code class="ic">llms.txt</code> at zero hosting/config cost.
+			We'll revisit an MCP only for agent <em>actions</em> a static file can't do.
+		</p>
 		<p class="sec__p" style="margin-top: 16px;">
 			Source: <a class="lnk" href={REPO} target="_blank" rel="noopener">github.com/rodriabregu/sve-ui</a>.
 		</p>

--- a/apps/docs/src/routes/llms.txt/+server.ts
+++ b/apps/docs/src/routes/llms.txt/+server.ts
@@ -1,0 +1,64 @@
+import { componentGroups } from '$lib/docs/registry';
+import { guideGroups } from '$lib/docs/guides';
+
+/**
+ * /llms.txt — an llmstxt.org index for AI agents, generated from the component
+ * registry and guide nav so it never drifts from the real catalog.
+ */
+export const prerender = true;
+
+const SITE = 'https://sveui.org';
+
+export function GET() {
+	const docs = guideGroups
+		.flatMap((g) => g.items.map((it) => `- [${it.name}](${SITE}${it.href})`))
+		.join('\n');
+
+	const components = componentGroups
+		.map((g) => {
+			const items = g.items
+				.filter((it) => it.ready)
+				.map((it) => `- [${it.name}](${SITE}/components/${it.slug}): ${it.blurb}`)
+				.join('\n');
+			return items ? `### ${g.label}\n${items}` : '';
+		})
+		.filter(Boolean)
+		.join('\n\n');
+
+	const soon = componentGroups
+		.flatMap((g) => g.items.filter((it) => !it.ready).map((it) => it.name))
+		.join(', ');
+
+	const body = `# sve-ui
+
+> Styled, accessible Svelte 5 components built on Bits UI. No Tailwind and no config in the consumer project: install, import the stylesheet once, and theme with CSS variables. Light and dark out of the box.
+
+## Usage rules
+
+- Install with \`pnpm add sve-ui\`. Import \`sve-ui/theme.css\` ONCE at the app root; without it components render unstyled. The consumer project needs no Tailwind and no config.
+- Single components are default imports: \`Button, Input, Badge, Spinner, Text, Heading, Slider, Code\`.
+- Composite components are namespaces composed with dots: \`Dialog.*, Select.*, Combobox.*, Card.*, Alert.*, Tabs.*, Accordion.*, Avatar.*, DropdownMenu.*, Popover.*, Tooltip.*, Switch.*, Checkbox.*, RadioGroup.*\`.
+- Overlays (Dialog/DropdownMenu/Popover/Tooltip/Select/Combobox) portal to <body>. Mirror the theme class (\`dark\`/\`light\`) onto <body> so portaled content gets the right --sve-* tokens.
+- Use a custom element as an overlay trigger via the Bits \`child\` snippet: \`<Dialog.Trigger>{#snippet child({ props })}<Button {...props}>Open</Button>{/snippet}</Dialog.Trigger>\`.
+- Theme by overriding \`--sve-*\` CSS variables. Do not put Tailwind layout/margin utilities on sve-ui components; scoped styles win, so wrap them in a <div> instead.
+- \`Slider\` uses \`value\` + \`onValueChange\` (not bind:value) and \`thumbLabel\` for an accessible name. \`Switch\`/\`Checkbox\` need \`aria-label\` when unlabelled. \`Tooltip\` requires a \`Tooltip.Provider\` ancestor.
+
+## Docs
+
+${docs}
+
+## Components
+
+${components}
+
+## Optional
+
+- [GitHub repository](https://github.com/rodriabregu/sve-ui): source, issues, and the sve-ui-usage agent skill at \`skills/sve-ui-usage/\`.
+- [npm package](https://www.npmjs.com/package/sve-ui)
+- Coming soon: ${soon}.
+`;
+
+	return new Response(body, {
+		headers: { 'content-type': 'text/plain; charset=utf-8' }
+	});
+}


### PR DESCRIPTION
## What

Adds a registry-generated **`/llms.txt`** so AI agents get an always-current index of sve-ui — and records the decision to **defer an MCP server**.

## Quick path to review
1. `apps/docs/src/routes/llms.txt/+server.ts` — prerendered endpoint that builds llms.txt from `componentGroups` + `guideGroups` (no drift).
2. `apps/docs/src/routes/docs/ai-agents/+page.svelte` — links llms.txt + documents the MCP decision.
3. `ROADMAP.md` §12 — decision recorded.

## The MCP evaluation (verdict: defer)

shadcn's MCP headline value is *browse + **install** components from a registry*. sve-ui is a **styled npm package** (decision D17), not a copy-paste registry — there's no "install component source" action, so that value doesn't apply. The remaining need (feed agents the real API) is already covered by the **skill** + **llms.txt** at zero hosting/config cost. An MCP would add a hosted service, maintenance, and per-consumer client config for marginal gain.

**Revisit an MCP** only for agent *actions* a static file can't do (scaffold a themed page, validate usage, generate compositions), or when auto-generated prop schemas grow large/volatile enough that querying beats a static file.

## Why an endpoint (not a static file)
Generating `/llms.txt` from the registry means it never drifts as components ship — `soon` items move to the catalog automatically.

## Verification
- `pnpm --filter docs check` → 830 files, **0 errors**
- `pnpm --filter docs lint` → **0 errors**
- `pnpm --filter docs build` → `/llms.txt` prerendered, all routes green

Docs-only — no library change, no changeset. Follow-up (open): ship `skills/` via the npm package `files`.